### PR TITLE
Functions

### DIFF
--- a/src/argon/node/function_call.py
+++ b/src/argon/node/function_call.py
@@ -1,0 +1,39 @@
+import typing
+import pydantic
+from pydantic.dataclasses import dataclass
+
+from argon.op import Op
+from argon.ref import Exp, Ref
+from argon.types.function import Function
+
+
+@dataclass(config=pydantic.ConfigDict(arbitrary_types_allowed=True))
+class FunctionCall[T](Op[T]):
+    """
+    The FunctionCall[T] operation represents a function call with return type T.
+
+        func : Function[T]
+            The function to call.
+        args : List[Ref[Any]]
+            The arguments to pass to the function.
+    """
+
+    func: Function[T]
+    args: typing.List[Ref[typing.Any, typing.Any]]
+
+    @property
+    @typing.override
+    def inputs(self) -> typing.List[Exp[typing.Any, typing.Any]]:
+        # TODO: figure out what inputs I should use
+        pass
+
+    @typing.override
+    def dump(self, indent_level=0) -> str:
+        no_indent = "|   " * indent_level
+        indent = "|   " * (indent_level + 1)
+        return (
+            f"FunctionCall( \n"
+            f"{indent}func = {self.func}, \n"
+            f"{indent}args = [{', '.join([str(arg) for arg in self.args])}] \n"
+            f"{no_indent})"
+        )

--- a/src/argon/node/function_new.py
+++ b/src/argon/node/function_new.py
@@ -1,0 +1,56 @@
+import typing
+import pydantic
+from pydantic.dataclasses import dataclass
+
+from argon.block import Block
+from argon.op import Op
+from argon.ref import Exp
+from argon.types.function import FunctionWithVirt
+
+
+@dataclass(config=pydantic.ConfigDict(arbitrary_types_allowed=True))
+class FunctionNew[T](Op[T]):
+    """
+    The FunctionNew[T] operation represents a new function with return type T.
+
+        name : str
+            The name of the function.
+        binds : List[Exp[Any]]
+            The binds of the function. These will specify the parameters of the function with their types.
+        body : Block[T]
+            The body of the function.
+        virtualized : FunctionWithVirt
+            The virtualized function to be used to create the Argon function.
+    """
+
+    name: str
+    binds: typing.List[Exp[typing.Any, typing.Any]]
+    body: Block
+    virtualized: typing.Optional[FunctionWithVirt] = None
+
+    @property
+    @typing.override
+    def inputs(self) -> typing.List[Exp[typing.Any, typing.Any]]:
+        # TODO: figure out what inputs I should use
+        return self.binds
+
+    @typing.override
+    def dump(self, indent_level=0) -> str:
+        no_indent = "|   " * indent_level
+        indent = "|   " * (indent_level + 1)
+        more_indent = "|   " * (indent_level + 2)
+        if self.binds:
+            binds_str = ", \n".join(
+                f"{more_indent}{bind.dump(indent_level + 2)}" for bind in self.binds
+            )
+            binds_str = f"[\n{binds_str}\n{indent}]"
+        else:
+            binds_str = "[]"
+        return (
+            f"FunctionNew( \n"
+            f"{indent}Name = {self.name}, \n"
+            f"{indent}Binds = {binds_str}, \n"
+            f"{indent}Body = {self.body.dump(indent_level + 1)}, \n"
+            f"{indent}Virtualized = {self.virtualized} \n"
+            f"{no_indent})"
+        )

--- a/src/argon/ref.py
+++ b/src/argon/ref.py
@@ -32,6 +32,13 @@ class ExpType[C, A](ArgonMeta, abc.ABC):
         empty_val.ctx = ctx
         return typing.cast(A, empty_val)  # type: ignore -- Pyright falsely reports the type is not compatible with the return type
 
+    def bound(self, name: str) -> A:
+        from argon.state import State
+
+        return self._new(
+            Def(Bound(State.get_current_state().next_id(), name)), SrcCtx.new(2)
+        )
+
     def const(self, c: C) -> A:
         return self._new(Def(Const(c)), SrcCtx.new(2))  # type: ignore -- Pyright falsely reports the type is not compatible with the return type
 
@@ -57,13 +64,14 @@ class ExpType[C, A](ArgonMeta, abc.ABC):
 @dataclass
 class Bound[A]:
     id: int
+    name: str
     def_type: typing.Literal["Bound"] = "Bound"
 
     def dump(self, indent_level=0) -> str:
-        return str(self)
+        return f"b{self.id} = Bound('{self.name}')"
 
     def __str__(self) -> str:
-        return f"Bound({self.id})"
+        return f"b{self.id}"
 
 
 @dataclass(config=pydantic.ConfigDict(arbitrary_types_allowed=True))

--- a/src/argon/types/__init__.py
+++ b/src/argon/types/__init__.py
@@ -1,0 +1,4 @@
+import argon.types.boolean
+import argon.types.function
+import argon.types.integer
+import argon.types.null

--- a/src/argon/types/boolean.py
+++ b/src/argon/types/boolean.py
@@ -1,9 +1,11 @@
 from typing import override
+import typing
 from argon.ref import Ref
 from argon.srcctx import SrcCtx
 from argon.state import stage
 
 import argon.node.logical as logical
+from argon.virtualization.type_mapper import concrete_to_abstract
 
 
 class Boolean(Ref[bool, "Boolean"]):
@@ -19,10 +21,25 @@ class Boolean(Ref[bool, "Boolean"]):
         return stage(logical.Not[Boolean](self), ctx=SrcCtx.new(2))
 
     def __and__(self, other: "Boolean") -> "Boolean":
+        other = typing.cast(Boolean, concrete_to_abstract(other))
         return stage(logical.And[Boolean](self, other), ctx=SrcCtx.new(2))
 
+    def __rand__(self, other: "Boolean") -> "Boolean":
+        return self & other
+
     def __or__(self, other: "Boolean") -> "Boolean":
+        other = typing.cast(Boolean, concrete_to_abstract(other))
         return stage(logical.Or[Boolean](self, other), ctx=SrcCtx.new(2))
 
+    def __ror__(self, other: "Boolean") -> "Boolean":
+        return self | other
+
     def __xor__(self, other: "Boolean") -> "Boolean":
+        other = typing.cast(Boolean, concrete_to_abstract(other))
         return stage(logical.Xor[Boolean](self, other), ctx=SrcCtx.new(2))
+
+    def __rxor__(self, other: "Boolean") -> "Boolean":
+        return self ^ other
+
+
+concrete_to_abstract[bool] = lambda x: Boolean().const(x)

--- a/src/argon/types/function.py
+++ b/src/argon/types/function.py
@@ -1,0 +1,69 @@
+import abc
+import types
+from typing import override, Protocol
+import typing
+from argon.block import Block
+from argon.ref import Ref
+from argon.srcctx import SrcCtx
+from argon.state import State, stage
+from argon.virtualization.func import ArgonFunction
+from argon.virtualization.type_mapper import concrete_to_abstract
+
+
+@typing.runtime_checkable
+class FunctionWithVirt(Protocol):
+    virtualized: ArgonFunction
+
+
+F = typing.TypeVar("F")
+
+
+class Function[F](Ref[FunctionWithVirt, "Function[F]"]):
+    """
+    The Function class represents a function in the Argon language.
+    """
+
+    @override
+    def fresh(self) -> "Function[F]":  # type: ignore -- Pyright falsely detects F as an abstractproperty instead of type variable
+        return Function[self.F]()
+
+    # F shim is used to silence typing errors -- its actual definition is provided by ArgonMeta
+    @abc.abstractproperty
+    def F(self) -> typing.Type[F]:
+        raise NotImplementedError()
+
+
+def function_C_to_A(
+    c: types.FunctionType, args: typing.List[Ref[typing.Any, typing.Any]]
+) -> Function:
+    if not (hasattr(c, "virtualized") and isinstance(c.virtualized, ArgonFunction)):  # type: ignore -- Pyright complains about accessing virtualized
+        from argon.virtualization.wrapper import argon_function
+
+        c_with_virt = argon_function()(c)
+    else:
+        c_with_virt = typing.cast(FunctionWithVirt, c)
+
+    # get the return type of a function by actually calling it
+    # TODO: add some check to see if we've already run it with args of the same type
+    param_names = c_with_virt.virtualized.get_param_names()
+    scope = State.get_current_state().new_scope()
+    with scope:
+        bound_args = [arg.bound(name) for arg, name in zip(args, param_names)]
+        ret = c_with_virt.virtualized.call_transformed(*bound_args)
+        ret = concrete_to_abstract(ret)
+
+    name = c_with_virt.virtualized.get_function_name()
+
+    from argon.virtualization.virtualizer import get_inputs
+
+    body = Block[ret.A](get_inputs(scope.scope.symbols), scope.scope.symbols, ret)
+
+    from argon.node.function_new import FunctionNew
+
+    return stage(
+        FunctionNew[Function[ret.A]](name, bound_args, body, c_with_virt),
+        ctx=SrcCtx.new(2),
+    )
+
+
+concrete_to_abstract[types.FunctionType] = function_C_to_A

--- a/src/argon/types/integer.py
+++ b/src/argon/types/integer.py
@@ -1,7 +1,10 @@
 from typing import override
+import typing
+from argon.node import arith
 from argon.ref import Ref
 from argon.srcctx import SrcCtx
 from argon.state import stage
+from argon.virtualization.type_mapper import concrete_to_abstract
 
 
 class Integer(Ref[int, "Integer"]):
@@ -14,6 +17,12 @@ class Integer(Ref[int, "Integer"]):
         return Integer()
 
     def __add__(self, other: "Integer") -> "Integer":
-        import argon.node.arith as arith
+        other = typing.cast(Integer, concrete_to_abstract(other))
 
         return stage(arith.Add[Integer](self, other), ctx=SrcCtx.new(2))
+
+    def __radd__(self, other: "Integer") -> "Integer":
+        return self + other
+
+
+concrete_to_abstract[int] = lambda x: Integer().const(x)

--- a/src/argon/types/null.py
+++ b/src/argon/types/null.py
@@ -1,6 +1,7 @@
 from types import NoneType
 from typing import override
 from argon.ref import Ref
+from argon.virtualization.type_mapper import concrete_to_abstract
 
 
 class Null(Ref[NoneType, "Null"]):
@@ -11,3 +12,6 @@ class Null(Ref[NoneType, "Null"]):
     @override
     def fresh(self) -> "Null":
         return Null()
+
+
+concrete_to_abstract[NoneType] = lambda x: Null().const(x)

--- a/src/argon/virtualization/func.py
+++ b/src/argon/virtualization/func.py
@@ -1,3 +1,4 @@
+import inspect
 import typing
 from pydantic.dataclasses import dataclass
 
@@ -18,3 +19,9 @@ class ArgonFunction:
 
     def call_transformed(self, *args, **kwargs):
         return self.transformed_func(*args, **kwargs, __________argon=self)
+
+    get_function_name = lambda self: self.original_func.__name__
+
+    def get_param_names(self) -> list[str]:
+        sig = inspect.signature(self.original_func)
+        return [param.name for param in sig.parameters.values()]

--- a/src/argon/virtualization/type_mapper.py
+++ b/src/argon/virtualization/type_mapper.py
@@ -1,0 +1,29 @@
+import types
+import typing
+from argon.ref import Ref
+
+
+class _CToA:
+    def __init__(self):
+        self.C_to_A_map = {}
+
+    def __setitem__(self, tp_c, tp_a_initializer: typing.Callable) -> None:
+        self.C_to_A_map[tp_c] = tp_a_initializer
+
+    def function(self, c, args: typing.List[Ref[typing.Any, typing.Any]]) -> "Function":
+        if not isinstance(c, types.FunctionType):
+            raise ValueError(f"Expected function, got {c}")
+        return self.C_to_A_map[types.FunctionType](c, args)
+
+    def __call__(self, c) -> Ref[typing.Any, typing.Any]:
+        if type(c) in self.C_to_A_map:
+            return self.C_to_A_map[type(c)](c)
+        elif isinstance(c, Ref):
+            return c
+        else:
+            raise ValueError(f"Cannot convert {c} to abstract type")
+
+
+concrete_to_abstract = _CToA()
+
+from argon.types.function import Function

--- a/src/argon/virtualization/wrapper.py
+++ b/src/argon/virtualization/wrapper.py
@@ -1,55 +1,85 @@
 import functools
 import inspect
 import ast
+import typing
 
+from argon.types.function import FunctionWithVirt
 from argon.virtualization.func import ArgonFunction
 from argon.virtualization.virtualizer import Transformer
 
 
-def argon_function(func):
-    # TODO: fix ctx, when this decorator is used in test_scopes.py,
-    # the ctx no longer points to the correct row number + col offset
+# TODO: After implementing more transformations, add relevant flags to the decorator to enable/disable them
+def argon_function(calls=True, ifs=True, if_exps=True):
+    """
+    This decorator is used to virtualize a function. It takes three optional arguments that are by default all set to True:
 
-    # Get the source code of the function
-    src = inspect.getsource(func)
-    # Parse it into an AST
-    parsed = ast.parse(src)
+        calls: bool
+            Determines whether function calls will be virtualized.
+        ifs: bool
+            Determines whether if statements will be virtualized.
+        if_exps: bool
+            Determines whether if expressions will be virtualized.
 
-    # Remove the decorators from the AST, because the modified function will
-    # be passed to them anyway and we don't want them to be called twice.
-    for node in parsed.body:
-        if isinstance(node, ast.FunctionDef) and node.name == func.__name__:
-            node.decorator_list = [
-                dec
-                for dec in node.decorator_list
-                if not (isinstance(dec, ast.Name) and dec.id == "argon_function")
-            ]
-            node.args.kw_defaults.append(ast.Constant(value=None))
-            node.args.kwonlyargs.append(ast.arg(arg="__________argon", annotation=None))
-            break
+    Examples:
 
-    # Apply the AST transformation
-    transformed = Transformer().visit(parsed)
-    transformed = ast.fix_missing_locations(transformed)
+        Tagging a function with `@argon_function()` will virtualize it with all transformations enabled.
 
-    print(ast.unparse(transformed))
+        Tagging a function with `@argon_function(calls=False)` will virtualize it with calls disabled and all other transformations enabled.
+    """
 
-    # Compile the transformed AST
-    compiled = compile(transformed, filename=func.__code__.co_filename, mode="exec")
-    # Create a new function from the compiled code
-    func_globals = func.__globals__
-    exec(compiled, func_globals)
+    def decorator(func) -> FunctionWithVirt:
+        # TODO: fix ctx, when this decorator is used in test_scopes.py,
+        # the ctx no longer points to the correct row number + col offset
 
-    # Replace the original function with the transformed version
-    virtualized_func = ArgonFunction(
-        func, functools.update_wrapper(func_globals[func.__name__], func)
-    )
+        # Get the source code of the function
+        src = inspect.getsource(func)
+        # Parse it into an AST
+        parsed = ast.parse(src)
 
-    # Create a wrapper function that calls the transformed function
-    # Pytest will not be able to collect the test functions if they are not
-    def wrapper(*args, **kwargs):
-        return virtualized_func.call_transformed(*args, **kwargs)
+        # Remove the decorators from the AST, because the modified function will
+        # be passed to them anyway and we don't want them to be called twice.
+        for node in parsed.body:
+            if isinstance(node, ast.FunctionDef) and node.name == func.__name__:
+                node.decorator_list = [
+                    dec
+                    for dec in node.decorator_list
+                    if not (
+                        (
+                            isinstance(dec, ast.Call)
+                            and isinstance(dec.func, ast.Name)
+                            and dec.func.id == "argon_function"
+                        )
+                    )
+                ]
+                node.args.kw_defaults.append(ast.Constant(value=None))
+                node.args.kwonlyargs.append(
+                    ast.arg(arg="__________argon", annotation=None)
+                )
+                break
 
-    wrapper.virtualized = virtualized_func  # type: ignore -- we need to add this flag to mark the function as virtualized
+        # Apply the AST transformation
+        # TODO: Add the transformation flags here too!
+        transformed = Transformer(calls, ifs, if_exps).visit(parsed)
+        transformed = ast.fix_missing_locations(transformed)
 
-    return functools.update_wrapper(wrapper, func)
+        # Compile the transformed AST
+        compiled = compile(transformed, filename=func.__code__.co_filename, mode="exec")
+        # Create a new function from the compiled code
+        func_globals = func.__globals__
+        exec(compiled, func_globals)
+
+        # Replace the original function with the transformed version
+        virtualized_func = ArgonFunction(
+            func, functools.update_wrapper(func_globals[func.__name__], func)
+        )
+
+        # Create a wrapper function that calls the transformed function
+        # Pytest will not be able to collect the test functions if they are not
+        def wrapper(*args, **kwargs):
+            return virtualized_func.call_original(*args, **kwargs)
+
+        wrapper.virtualized = virtualized_func  # type: ignore -- we need to add this flag to mark the function as virtualized
+
+        return typing.cast(FunctionWithVirt, functools.update_wrapper(wrapper, func))
+
+    return decorator

--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -1,0 +1,14 @@
+from argon.state import State
+from argon.types.boolean import Boolean
+
+
+def test_boolean():
+    state = State()
+    with state:
+        a = Boolean().const(True)
+        b = Boolean().const(False)
+        c = a & b
+        d = c | b
+        e = ~d
+        f = e ^ a
+    print(state)

--- a/tests/test_bound.py
+++ b/tests/test_bound.py
@@ -1,0 +1,21 @@
+from argon.state import State
+from argon.types.boolean import Boolean
+from argon.types.integer import Integer
+
+
+def test_bound():
+    state = State()
+    with state:
+        a = Boolean().bound("x")
+        assert isinstance(a, Boolean)
+
+        b = Boolean().const(True)
+        b = b.bound("y")
+        assert isinstance(b, Boolean)
+
+        c = Integer().bound("m")
+        assert isinstance(c, Integer)
+
+        d = Integer().const(1)
+        d = d.bound("n")
+        assert isinstance(d, Integer)

--- a/tests/test_c_to_a.py
+++ b/tests/test_c_to_a.py
@@ -1,0 +1,34 @@
+from types import NoneType
+from argon.state import State
+from argon.types.boolean import Boolean
+from argon.types.integer import Integer
+from argon.types.null import Null
+from argon.virtualization.type_mapper import concrete_to_abstract
+
+
+def func(x):
+    return x
+
+
+def test_c_to_a():
+    state = State()
+    with state:
+        a = 3
+        a1 = concrete_to_abstract(a)
+        assert a1.C is int
+        assert a1.A is Integer
+
+        b = True
+        b1 = concrete_to_abstract(b)
+        assert b1.C is bool
+        assert b1.A is Boolean
+
+        c = None
+        c1 = concrete_to_abstract(c)
+        assert c1.C is NoneType
+        assert c1.A is Null
+
+        d = func
+        d1 = concrete_to_abstract.function(d, [concrete_to_abstract(3)])
+        assert d1.F is Integer
+    print(state)

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -1,0 +1,64 @@
+from argon.state import State
+from argon.types.boolean import Boolean
+from argon.types.integer import Integer
+from argon.virtualization.wrapper import argon_function
+
+
+@argon_function(calls=False, ifs=False)
+def if_exps():
+    a = Boolean().const(True)
+    b = Boolean().const(False)
+    c = Integer().const(3)
+    d = Integer().const(6)
+    e = Integer().const(9)
+    f = Integer().const(12)
+    g = c + d if a & b else e + f
+    h = g + g if a | b else Integer().const(15)
+
+
+def test_if_exps():
+    state = State()
+    with state:
+        if_exps.virtualized.call_transformed()
+
+    print(f"\ntest_if_exps")
+    print(state)
+
+
+@argon_function(calls=False, if_exps=False)
+def ifs():
+    a = Boolean().const(True)
+    b = Boolean().const(False)
+
+    c = Integer().const(3)
+    d = Integer().const(6)
+    e = Integer().const(9)
+    f = Integer().const(12)
+    g = Integer().const(15)
+    h = Integer().const(18)
+    i = Integer().const(21)
+    j = Integer().const(24)
+    k = Integer().const(27)
+    l = Integer().const(30)
+
+    if a & b:
+        m = c + d
+    else:
+        m = e + f
+
+    if a | b:
+        m = g + h
+    else:
+        if a ^ b:
+            m = i + j
+        else:
+            m = k + l
+
+
+def test_ifs():
+    state = State()
+    with state:
+        ifs.virtualized.call_transformed()
+
+    print(f"\ntest_ifs")
+    print(state)

--- a/tests/test_function_call.py
+++ b/tests/test_function_call.py
@@ -1,0 +1,18 @@
+from argon.state import State
+from argon.virtualization.wrapper import argon_function
+
+
+def func(x, y):
+    return x + y
+
+
+@argon_function()
+def function_call():
+    return func(3, 4) + 5
+
+
+def test_function_call():
+    state = State()
+    with state:
+        function_call.virtualized.call_transformed()
+    print(state)

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -1,7 +1,5 @@
 from argon.state import State
 from argon.types.integer import Integer
-from argon.types.boolean import Boolean
-from argon.virtualization.wrapper import argon_function
 
 
 def test_scope():
@@ -11,73 +9,6 @@ def test_scope():
         b = Integer().const(6)
         c = a + b
         d = c + b
-    print(state)
 
     print(f"\ntest_scope")
-    print(state)
-
-
-def test_scope2():
-    state = State()
-    with state:
-        a = Boolean().const(True)
-        b = Boolean().const(False)
-        c = a & b
-        d = c | b
-        e = ~d
-        f = e ^ a
-
-    print(f"\ntest_scope2")
-    print(state)
-
-
-@argon_function
-def test_scope3():
-    state = State()
-    with state:
-        a = Boolean().const(True)
-        b = Boolean().const(False)
-        c = Integer().const(3)
-        d = Integer().const(6)
-        e = Integer().const(9)
-        f = Integer().const(12)
-        g = c + d if a & b else e + f
-        h = g if a | b else Integer().const(15)
-
-    print(f"\ntest_scope3")
-    print(state)
-
-
-@argon_function
-def test_scope4():
-    state = State()
-    with state:
-        a = Boolean().const(True)
-        b = Boolean().const(False)
-
-        c = Integer().const(3)
-        d = Integer().const(6)
-        e = Integer().const(9)
-        f = Integer().const(12)
-        g = Integer().const(15)
-        h = Integer().const(18)
-        i = Integer().const(21)
-        j = Integer().const(24)
-        k = Integer().const(27)
-        l = Integer().const(30)
-
-        if a & b:
-            m = c + d
-        else:
-            m = e + f
-
-        if a | b:
-            m = g + h
-        else:
-            if a ^ b:
-                m = i + j
-            else:
-                m = k + l
-
-    print(f"\ntest_scope4")
     print(state)


### PR DESCRIPTION
# Supporting the Staging of Function Calls

## Creating a new Function type

### FunctionWithVirt
Much like all the previous types that we have created, we want the concrete type of `Function` to be a Python function. The easiest way to do this would be to simply make the concrete type  `types.FunctionType` to capture the original Python function. However, this fails to take into account that in order to ultimately use and stage calls with `Function`, our `Function` must come from a virtualized function. As a result, we can create a `FunctionWithVirt` protocol with a `virtualized: ArgonFunction` attribute that stores both the original and the virtualized functions. Our `argon_function` decorator in `argon/virtualization/wrapper.py` works with this to return a `FunctionWithVirt` when applied to a given function.

```python
@typing.runtime_checkable
class FunctionWithVirt(Protocol):
    virtualized: ArgonFunction
```

### Function
This allows us to define our `Function` type as we typically would with the type parameter `F` being the return type of our function.

```python
class Function[F](Ref[FunctionWithVirt, "Function[F]"]):
    ...
```

## Staging to Create Instances of Function

### Binds
Due to dynamic typing in Python, we are unable to simply extract the return type of a given function. Since the return type of a function can be dependent on its arguments, we address this by creating binds for each parameter with our desired type. For example, we can create a bind of type `Integer` for a parameter of name `x` by running `Integer().bound("x")`. We can then run our virtualized function with the binds we have created to not only get the return type of the function, but also the entire graph for the function.

### FunctionNew
The aforementioned approach creates critical metadata for a `Function`, which we store in a `FunctionNew` operation that inherits from `Op`. The class attribute `binds` stores a list of the binds that will be used to create the `Function`, and the class attribute `body` stores the graph we get from executing our function with our binds. Recall that since `body` is a `Block`, it contains a list of inputs to our function (e.g. values used in our function that were defined outside the function), a list of the nodes staged when executing the function with our binds, and the return result from executing the function.

```python
@dataclass(config=pydantic.ConfigDict(arbitrary_types_allowed=True))
class FunctionNew[T](Op[T]):
    ...
    name: str
    binds: typing.List[Exp[typing.Any, typing.Any]]
    body: Block
    virtualized: typing.Optional[FunctionWithVirt] = None
    ...
```

With all our metadata stored in an instance of `FunctionNew`, we can then stage it to get our desired `Function` with its correct return type.

## Staging Function Calls

### Creating a new FunctionCall Operation
With a new Argon type `Function` for functions now, what remains is a `FunctionCall` operation that stores the necessary metadata to stage a call to a function. The class attribute `func` stores the `Function` to be called, and `args` stores a list of the arguments. The return type of our function call is stored in the type parameter `T`.

```python
@dataclass(config=pydantic.ConfigDict(arbitrary_types_allowed=True))
class FunctionCall[T](Op[T]):
    ...
    func: Function[T]
    args: typing.List[Ref[typing.Any, typing.Any]]
    ...
```

We now have most of the infrastructure to stage function calls, however, we still have some major issues to tackle.

### Mapping Concrete to Abstract Types
One issue we have is to ensure that we only work with Argon types when staging function calls. This is important because we need to be able to create binds of the correct Argon type, get the correct graph for our function based on these binds, and thus correctly capture the Argon type that `Function` should return. As a result, when staging function calls, we need to make sure that all of our arguments are converted to Argon types. Moreover, for functions that return None, we also need to convert that to an Argon `Null`.

To facilitate this type conversion, we create a concrete to abstract type mapper in `argon/virtualization/type_mapper.py` called `_CToA`. Since we only want one shared type mapper across the entire program, we create an instance of `_CToA` called `concrete_to_abstract` that is public, and we included the leading single underscore in the name of `_CToA` to emphasize that the class itself should be non-public.

Within our type mapper is a dictionary where concrete types are keys that map to callables that return its corresponding abstract instance. Considering an example with bool as the concrete type and Boolean as the abstract type, we can add a mapping with `bool` as the key and `lambda x: Boolean().const(x)` as the value. To make it more flexible for users to add mappings when defining their own Argon types, we implement the `__setitem__` method so that directly following a user's class definition of an abstract type, they can do something like the following:

```python
class Boolean(Ref[bool, "Boolean"]):
    ...

concrete_to_abstract[bool] = lambda x: Boolean().const(x)
```

More critically, we can also use this type mapper to create instances of `Function` from normal functions. Directly following our definition of the `Function` class, we create a callable that takes in the concrete function and arguments that we want to call the function with, and returns a `Function`. This callable takes care of the aforementioned process of creating binds, getting the graph of the concrete function, and staging the `FunctionNew`. For functions that return None, this callable can use our type mapper to convert the return value to an Argon `Null`.

```python
class Function[F](Ref[FunctionWithVirt, "Function[F]"]):
    ...

def function_C_to_A(
    c: types.FunctionType, args: typing.List[Ref[typing.Any, typing.Any]]
) -> Function:
    ...

concrete_to_abstract[types.FunctionType] = function_C_to_A
```

Notice that since we are creating these mappings after the class definitions for our abstract types, these mappings will be available for us right when we import its module. However, since we might need mappings that we don't explicitly import, we need to prevent errors by importing all abstract types in the `argon/types/__init__.py`.

Here is an example of how to use `concrete_to_abstract` on all the abstract types that we currently support:
```python
def func(x):
    return x


def test_c_to_a():
    state = State()
    with state:
        a = 3
        a1 = concrete_to_abstract(a)
        assert a1.C is int
        assert a1.A is Integer

        b = True
        b1 = concrete_to_abstract(b)
        assert b1.C is bool
        assert b1.A is Boolean

        c = None
        c1 = concrete_to_abstract(c)
        assert c1.C is NoneType
        assert c1.A is Null

        d = func
        d1 = concrete_to_abstract.function(d, [concrete_to_abstract(3)])
        assert d1.F is Integer
    print(state)
```

## Staging a Function Call + White Listing Certain Functions
With all types and operations created, as well as the new type mapper, we can stage a function call by using our type mapper to convert all concrete arguments to abstract arguments and our concrete function to an abstract function, creating a `FunctionCall` instance with these abstract arguments and abstract function, and finally staging the `FunctionCall`.

```python
def stage_function_call(func: types.FunctionType, args: typing.List[typing.Any]) -> Ref[typing.Any, typing.Any]:
    ...
    abstract_args = [concrete_to_abstract(arg) for arg in args]
    abstract_func = concrete_to_abstract.function(func, abstract_args)
    return stage(FunctionCall[abstract_func.F](abstract_func, abstract_args), ctx=SrcCtx.new(2))
```

We can then modify our `Transformer` in `argon/virtualization/virtualizer.py` by adding a `visit_Call` function and change all function calls to calls to `stage_function_call` via AST manipulation. There are, however, certain functions that we want to white list (e.g. print) and not transform. As a result, in `stage_function_call`, we also need to check if our function is in our white list, and if so, then we simply execute it as is and return its results instead of staging a `FunctionCall` for it as we normally would.

## Selective Virtualization
To allow for the opportunity to selectively virtualize different control features (e.g. ifs, if expressions, function calls), we modify the `argon_function` decorator to take in boolean flags for each feature. These flags are propagated through to `Transformer` where it can selectively apply AST manipulations to different nodes. Note that flags are set to True by default (i.e. all features are virtualized by default). For example, tagging a function with `@argon_function()` will virtualize it with all transformations enabled, whereas tagging a function with `@argon_function(calls=False)` will virtualize it with calls disabled and all other transformations enabled.

* Side note: I also reorganized the tests to be clearer in terms of the features they are testing.