### PR TITLE
Loops

### DIFF
--- a/src/argon/node/arith.py
+++ b/src/argon/node/arith.py
@@ -47,7 +47,7 @@ class Sub[T](Op[T]):
     @property
     @typing.override
     def operands(self) -> typing.List[Sym[typing.Any]]:
-        return [self.a, self.b]
+        return [self.a, self.b]  # type: ignore
 
 
 @dataclass(config=pydantic.ConfigDict(arbitrary_types_allowed=True))
@@ -67,7 +67,7 @@ class GreaterThan[T](Op[Boolean]):
     @property
     @typing.override
     def operands(self) -> typing.List[Sym[typing.Any]]:
-        return [self.a, self.b]
+        return [self.a, self.b]  # type: ignore
 
 
 @dataclass(config=pydantic.ConfigDict(arbitrary_types_allowed=True))
@@ -87,4 +87,4 @@ class LessThan[T](Op[Boolean]):
     @property
     @typing.override
     def operands(self) -> typing.List[Sym[typing.Any]]:
-        return [self.a, self.b]
+        return [self.a, self.b]  # type: ignore

--- a/src/argon/node/arith.py
+++ b/src/argon/node/arith.py
@@ -26,7 +26,7 @@ class Add[T](Op[T]):
 
     @property
     @typing.override
-    def inputs(self) -> typing.List[Sym[typing.Any]]:
+    def operands(self) -> typing.List[Sym[typing.Any]]:
         return [self.a, self.b]  # type: ignore
 
 
@@ -46,7 +46,7 @@ class Sub[T](Op[T]):
 
     @property
     @typing.override
-    def inputs(self) -> typing.List[Sym[typing.Any]]:
+    def operands(self) -> typing.List[Sym[typing.Any]]:
         return [self.a, self.b]
 
 
@@ -66,7 +66,7 @@ class GreaterThan[T](Op[Boolean]):
 
     @property
     @typing.override
-    def inputs(self) -> typing.List[Sym[typing.Any]]:
+    def operands(self) -> typing.List[Sym[typing.Any]]:
         return [self.a, self.b]
 
 
@@ -86,5 +86,5 @@ class LessThan[T](Op[Boolean]):
 
     @property
     @typing.override
-    def inputs(self) -> typing.List[Sym[typing.Any]]:
+    def operands(self) -> typing.List[Sym[typing.Any]]:
         return [self.a, self.b]

--- a/src/argon/node/arith.py
+++ b/src/argon/node/arith.py
@@ -2,8 +2,9 @@ import typing
 import pydantic
 from argon.ref import Exp, Op, Sym
 
-# from argon.types.integer import Integer
 from pydantic.dataclasses import dataclass
+
+from argon.types.boolean import Boolean
 
 
 T = typing.TypeVar("T", bound=Exp[typing.Any, typing.Any], covariant=True)
@@ -27,3 +28,63 @@ class Add[T](Op[T]):
     @typing.override
     def inputs(self) -> typing.List[Sym[typing.Any]]:
         return [self.a, self.b]  # type: ignore
+
+
+@dataclass(config=pydantic.ConfigDict(arbitrary_types_allowed=True))
+class Sub[T](Op[T]):
+    """
+    The Sub[T] operation represents a subtraction operation.
+
+        a : T
+            The value to subtract from.
+        b : T
+            The value to subtract.
+    """
+
+    a: T
+    b: T
+
+    @property
+    @typing.override
+    def inputs(self) -> typing.List[Sym[typing.Any]]:
+        return [self.a, self.b]
+
+
+@dataclass(config=pydantic.ConfigDict(arbitrary_types_allowed=True))
+class GreaterThan[T](Op[Boolean]):
+    """
+    The GreaterThan[T] operation represents a greater than comparison.
+
+        a : T
+            The first value to compare.
+        b : T
+            The second value to compare.
+    """
+
+    a: T
+    b: T
+
+    @property
+    @typing.override
+    def inputs(self) -> typing.List[Sym[typing.Any]]:
+        return [self.a, self.b]
+
+
+@dataclass(config=pydantic.ConfigDict(arbitrary_types_allowed=True))
+class LessThan[T](Op[Boolean]):
+    """
+    The LessThan[T] operation represents a less than comparison.
+
+        a : T
+            The first value to compare.
+        b : T
+            The second value to compare.
+    """
+
+    a: T
+    b: T
+
+    @property
+    @typing.override
+    def inputs(self) -> typing.List[Sym[typing.Any]]:
+        return [self.a, self.b]

--- a/src/argon/node/control.py
+++ b/src/argon/node/control.py
@@ -43,3 +43,61 @@ class IfThenElse[T](Op[T]):
             f"{indent}elseBlk = {self.elseBlk.dump(indent_level + 1)} \n"
             f"{no_indent})"
         )
+
+
+@dataclass(config=pydantic.ConfigDict(arbitrary_types_allowed=True))
+class Loop(Op[Null]):
+    """
+    The Loop operation represents both for and while loop control flow constructs.
+
+        cond : Boolean
+            The condition to check.
+        body : Block[Null]
+            The loop body to execute if the condition is true.
+    """
+
+    values: typing.List[Exp[typing.Any, typing.Any]]
+    binds: typing.List[Exp[typing.Any, typing.Any]]
+    cond: Block[Boolean]
+    body: Block[Null]
+    outputs: typing.Any
+
+    @pydantic.field_validator("outputs")
+    def check_outputs(cls, v):
+        if not hasattr(v, "_fields") or not hasattr(v, "_asdict"):
+            raise ValueError("outputs must be a namedtuple or similar structure.")
+        return v
+
+    @property
+    @typing.override
+    def inputs(self) -> typing.List[Sym[typing.Any]]:
+        return self.cond.inputs + self.body.inputs
+
+    @typing.override
+    def dump(self, indent_level=0) -> str:
+        no_indent = "|   " * indent_level
+        indent = "|   " * (indent_level + 1)
+        more_indent = "|   " * (indent_level + 2)
+        values_str = ", ".join(f"{value}" for value in self.values)
+        values_str = f"[{values_str}]"
+        if self.binds:
+            binds_str = ", \n".join(
+                f"{more_indent}{bind.dump(indent_level + 2)}" for bind in self.binds
+            )
+            binds_str = f"[\n{binds_str}\n{indent}]"
+        else:
+            binds_str = "[]"
+        outputs_str = ", ".join(
+            f"{key} = {value}" for key, value in self.outputs._asdict().items()
+        )
+        outputs_str = f"({outputs_str})"
+        return (
+            f"Loop( \n"
+            f"{indent}values = {values_str}, \n"
+            f"{indent}binds = {binds_str}, \n"
+            f"{indent}cond = {self.cond.dump(indent_level + 1)}, \n"
+            f"{indent}body = {self.body.dump(indent_level + 1)}, \n"
+            # print the field value pairs of outputs
+            f"{indent}outputs = {outputs_str} \n"
+            f"{no_indent})"
+        )

--- a/src/argon/node/control.py
+++ b/src/argon/node/control.py
@@ -46,7 +46,7 @@ class IfThenElse[T](Op[T]):
 
 
 @dataclass(config=pydantic.ConfigDict(arbitrary_types_allowed=True))
-class Loop(Op[Null]):
+class Loop[T](Op[T]):
     """
     The Loop operation represents both for and while loop control flow constructs.
 

--- a/src/argon/node/control.py
+++ b/src/argon/node/control.py
@@ -23,14 +23,14 @@ class IfThenElse[T](Op[T]):
             The block to execute if the condition is false.
     """
 
-    cond: Boolean
+    condBlk: Block[Boolean]
     thenBlk: Block[T]
     elseBlk: Block[T]
 
     @property
     @typing.override
     def inputs(self) -> typing.List[Sym[typing.Any]]:
-        return [self.cond] + self.thenBlk.inputs + self.elseBlk.inputs  # type: ignore
+        return self.condBlk.inputs + self.thenBlk.inputs + self.elseBlk.inputs  # type: ignore
 
     @typing.override
     def dump(self, indent_level=0) -> str:
@@ -38,7 +38,7 @@ class IfThenElse[T](Op[T]):
         indent = "|   " * (indent_level + 1)
         return (
             f"IfThenElse( \n"
-            f"{indent}cond = {self.cond}, \n"
+            f"{indent}condBlk = {self.condBlk.dump(indent_level + 1)}, \n"
             f"{indent}thenBlk = {self.thenBlk.dump(indent_level + 1)}, \n"
             f"{indent}elseBlk = {self.elseBlk.dump(indent_level + 1)} \n"
             f"{no_indent})"

--- a/src/argon/node/control.py
+++ b/src/argon/node/control.py
@@ -4,8 +4,9 @@ from pydantic.dataclasses import dataclass
 
 from argon.block import Block
 from argon.op import Op
-from argon.ref import Sym
+from argon.ref import Exp, Sym
 from argon.types.boolean import Boolean
+from argon.types.null import Null
 
 
 @dataclass(config=pydantic.ConfigDict(arbitrary_types_allowed=True))

--- a/src/argon/node/dict_ops.py
+++ b/src/argon/node/dict_ops.py
@@ -1,0 +1,19 @@
+import typing
+import pydantic
+from pydantic.dataclasses import dataclass
+
+from argon.op import Op
+from argon.ref import Exp
+
+
+@dataclass(config=pydantic.ConfigDict(arbitrary_types_allowed=True))
+class Get[T](Op[T]):
+    dictionary: Exp
+    # TODO: Only restricting keys to str for now
+    key: str
+
+    @property
+    @typing.override
+    def operands(self) -> typing.List[Exp[typing.Any, typing.Any]]:
+        return [self.dictionary, self.key]
+

--- a/src/argon/node/function_call.py
+++ b/src/argon/node/function_call.py
@@ -23,7 +23,7 @@ class FunctionCall[T](Op[T]):
 
     @property
     @typing.override
-    def inputs(self) -> typing.List[Exp[typing.Any, typing.Any]]:
+    def operands(self) -> typing.List[Exp[typing.Any, typing.Any]]:
         # TODO: figure out what inputs I should use
         return self.args
 

--- a/src/argon/node/function_call.py
+++ b/src/argon/node/function_call.py
@@ -3,7 +3,7 @@ import pydantic
 from pydantic.dataclasses import dataclass
 
 from argon.op import Op
-from argon.ref import Exp, Ref
+from argon.ref import Exp
 from argon.types.function import Function
 
 
@@ -14,12 +14,12 @@ class FunctionCall[T](Op[T]):
 
         func : Function[T]
             The function to call.
-        args : List[Ref[Any]]
+        args : List[Exp[Any]]
             The arguments to pass to the function.
     """
 
     func: Function[T]
-    args: typing.List[Ref[typing.Any, typing.Any]]
+    args: typing.List[Exp[typing.Any, typing.Any]]
 
     @property
     @typing.override

--- a/src/argon/node/function_new.py
+++ b/src/argon/node/function_new.py
@@ -30,9 +30,9 @@ class FunctionNew[T](Op[T]):
 
     @property
     @typing.override
-    def inputs(self) -> typing.List[Exp[typing.Any, typing.Any]]:
+    def operands(self) -> typing.List[Exp[typing.Any, typing.Any]]:
         # TODO: figure out what inputs I should use
-        return self.binds
+        return []
 
     @typing.override
     def dump(self, indent_level=0) -> str:

--- a/src/argon/node/logical.py
+++ b/src/argon/node/logical.py
@@ -20,7 +20,7 @@ class Not[T](Op[T]):
 
     @property
     @typing.override
-    def inputs(self) -> typing.List[Sym[typing.Any]]:
+    def operands(self) -> typing.List[Sym[typing.Any]]:
         return [self.a]  # type: ignore
 
 
@@ -40,7 +40,7 @@ class And[T](Op[T]):
 
     @property
     @typing.override
-    def inputs(self) -> typing.List[Sym[typing.Any]]:
+    def operands(self) -> typing.List[Sym[typing.Any]]:
         return [self.a, self.b]  # type: ignore
 
 
@@ -60,7 +60,7 @@ class Or[T](Op[T]):
 
     @property
     @typing.override
-    def inputs(self) -> typing.List[Sym[typing.Any]]:
+    def operands(self) -> typing.List[Sym[typing.Any]]:
         return [self.a, self.b]  # type: ignore
 
 
@@ -80,5 +80,5 @@ class Xor[T](Op[T]):
 
     @property
     @typing.override
-    def inputs(self) -> typing.List[Sym[typing.Any]]:
+    def operands(self) -> typing.List[Sym[typing.Any]]:
         return [self.a, self.b]  # type: ignore

--- a/src/argon/node/phi.py
+++ b/src/argon/node/phi.py
@@ -26,5 +26,5 @@ class Phi[T](Op[T]):
 
     @property
     @typing.override
-    def inputs(self) -> typing.List[Sym[typing.Any]]:
+    def operands(self) -> typing.List[Sym[typing.Any]]:
         return [self.cond, self.a, self.b]  # type: ignore

--- a/src/argon/node/struct_ops.py
+++ b/src/argon/node/struct_ops.py
@@ -4,16 +4,17 @@ from pydantic.dataclasses import dataclass
 
 from argon.op import Op
 from argon.ref import Exp
+from argon.types.struct import Struct
 
 
 @dataclass(config=pydantic.ConfigDict(arbitrary_types_allowed=True))
 class Get[T](Op[T]):
-    dictionary: Exp
+    # Note: The proper type should be a Struct whose type parameter contains an element T
+    struct: Struct
     # TODO: Only restricting keys to str for now
     key: str
 
     @property
     @typing.override
     def operands(self) -> typing.List[Exp[typing.Any, typing.Any]]:
-        return [self.dictionary, self.key]
-
+        return [self.struct, self.key]

--- a/src/argon/node/struct_ops.py
+++ b/src/argon/node/struct_ops.py
@@ -17,4 +17,4 @@ class Get[T](Op[T]):
     @property
     @typing.override
     def operands(self) -> typing.List[Exp[typing.Any, typing.Any]]:
-        return [self.struct, self.key]
+        return [self.struct]

--- a/src/argon/node/struct_ops.py
+++ b/src/argon/node/struct_ops.py
@@ -18,3 +18,7 @@ class Get[T](Op[T]):
     @typing.override
     def operands(self) -> typing.List[Exp[typing.Any, typing.Any]]:
         return [self.struct]
+    
+    @typing.override
+    def dump(self, indent_level=0) -> str:
+        return f"Get({self.struct}, '{self.key}')"

--- a/src/argon/node/undefined.py
+++ b/src/argon/node/undefined.py
@@ -23,7 +23,7 @@ class Undefined[T](Op[T]):
 
     @property
     @typing.override
-    def inputs(self) -> typing.List[Sym[typing.Any]]:
+    def operands(self) -> typing.List[Sym[typing.Any]]:
         return []  # type: ignore
 
     @typing.override

--- a/src/argon/op.py
+++ b/src/argon/op.py
@@ -18,15 +18,19 @@ class Op[R](ArgonMeta, abc.ABC):
     class should be subclassed to define custom operations.
     """
 
-    @abc.abstractproperty
+    @property
     def inputs(self) -> typing.List["Sym[typing.Any]"]:
+        return [operand for operand in self.operands if operand.is_node()]
+    
+    @property
+    def operands(self) -> typing.List["Sym[typing.Any]"]:
         raise NotImplementedError()
 
     def dump(self, indent_level=0) -> str:
         return str(self)
 
     def __str__(self) -> str:
-        return f"{self.__class__.__name__}({', '.join(map(str, self.inputs))})"
+        return f"{self.__class__.__name__}({', '.join(map(str, self.operands))})"
 
 
 from argon.ref import Sym

--- a/src/argon/ref.py
+++ b/src/argon/ref.py
@@ -143,6 +143,18 @@ class Exp[C, A](ArgonMeta, abc.ABC):
     def tp(self) -> ExpType[C, A]:
         raise NotImplementedError()
 
+    def is_bound(self) -> bool:
+        return self.rhs != None and isinstance(self.rhs.val, Bound)
+
+    def is_node(self) -> bool:
+        return self.rhs != None and isinstance(self.rhs.val, Node)
+
+    def is_const(self) -> bool:
+        return self.rhs != None and isinstance(self.rhs.val, Const)
+
+    def is_typeref(self) -> bool:
+        return self.rhs != None and isinstance(self.rhs.val, TypeRef)
+
     def dump(self, indent_level=0) -> str:
         no_indent = "|   " * indent_level
         indent = "|   " * (indent_level + 1)

--- a/src/argon/state.py
+++ b/src/argon/state.py
@@ -108,7 +108,7 @@ class Scope:
         node_symbols = [
             symbol
             for symbol in self.symbols
-            if symbol.is_node() and not isinstance(symbol.rhs.val.underlying, Phi)
+            if symbol.is_node() and not isinstance(symbol.rhs.val.underlying, Phi)  # type: ignore -- symbol.rhs.val has already been checked to be a Node
         ]
 
         # We use a symbol's id instead of just the symbol objects below because symbols

--- a/src/argon/state.py
+++ b/src/argon/state.py
@@ -101,6 +101,34 @@ class Scope:
         pydantic.Field(default_factory=dict)
     )
 
+    @property
+    def inputs(self) -> typing.List[Exp[typing.Any, typing.Any]]:
+        # We only want to consider symbols that have inputs in their rhs (i.e. Nodes)
+        # We also want to exclude Phi nodes from the list of inputs
+        node_symbols = [
+            symbol
+            for symbol in self.symbols
+            if symbol.is_node() and not isinstance(symbol.rhs.val.underlying, Phi)
+        ]
+
+        # We use a symbol's id instead of just the symbol objects below because symbols
+        # are not hashable and Python complains.
+        # Create a dictionary mapping IDs to symbols
+        symbol_map = {symbol.rhs.val.id: symbol for symbol in node_symbols}  # type: ignore -- symbol.rhs.val has already been checked to be a Node
+
+        all_symbol_ids = set(symbol_map.keys())
+
+        # The list of inputs in our scope constitutes the set of all inputs of all symbols
+        # minus the set of all symbols defined in this scope
+        all_input_ids = set()
+        for symbol in node_symbols:
+            inputs = symbol.rhs.val.underlying.inputs  # type: ignore -- symbol.rhs.val has already been checked to be a Node
+            symbol_map.update({input.rhs.val.id: input for input in inputs})  # type: ignore -- input.rhs.val has already been checked to be a Node
+            all_input_ids.update({input.rhs.val.id for input in inputs})  # type: ignore -- input.rhs.val has already been checked to be a Node
+
+        result_ids = all_input_ids - all_symbol_ids
+        return [symbol_map[result_id] for result_id in result_ids]
+
     def dump(self, indent_level=0) -> str:
         no_indent = "|   " * indent_level
         indent = "|   " * (indent_level + 1)
@@ -145,3 +173,5 @@ def stage[A](op: Op[A], ctx: SrcCtx | None = None) -> A:
     state = State.get_current_state()
     ctx = ctx or SrcCtx.new(2)
     return state.stage(op, ctx)
+
+from argon.node.phi import Phi

--- a/src/argon/types/__init__.py
+++ b/src/argon/types/__init__.py
@@ -2,4 +2,4 @@ import argon.types.boolean
 import argon.types.function
 import argon.types.integer
 import argon.types.null
-import argon.types.dictionary
+import argon.types.struct

--- a/src/argon/types/__init__.py
+++ b/src/argon/types/__init__.py
@@ -2,3 +2,4 @@ import argon.types.boolean
 import argon.types.function
 import argon.types.integer
 import argon.types.null
+import argon.types.dictionary

--- a/src/argon/types/dictionary.py
+++ b/src/argon/types/dictionary.py
@@ -1,0 +1,29 @@
+from typing import override
+import typing
+from argon.node.dict_ops import Get
+from argon.ref import Ref
+from argon.srcctx import SrcCtx
+from argon.state import stage
+
+
+T = typing.TypeVar("T")
+
+
+class Dictionary[T](Ref[dict, "Dictionary[T]"]):
+    """
+    The NamedTuple[T] class represents a namedtuple in the Argon
+    language. The type parameter T is a namedtuple with keys
+    mapping to the types of the values in the NamedTuple.
+    """
+
+    @override
+    def fresh(self) -> "Dictionary[T]":
+        return Dictionary[self.T]()
+
+    # TODO: Only restricting keys to str for now
+    def __getitem__(self, key: str) -> T:
+        try:
+            item_tp = self.T[key]
+        except KeyError:
+            raise KeyError(f"Key '{key}' not found in dictionary {self}")
+        return stage(Get[item_tp](self, key), ctx=SrcCtx.new(2))

--- a/src/argon/types/function.py
+++ b/src/argon/types/function.py
@@ -47,17 +47,15 @@ def function_C_to_A(
     # get the return type of a function by actually calling it
     # TODO: add some check to see if we've already run it with args of the same type
     param_names = c_with_virt.virtualized.get_param_names()
-    scope = State.get_current_state().new_scope()
-    with scope:
+    scope_context = State.get_current_state().new_scope()
+    with scope_context:
         bound_args = [arg.bound(name) for arg, name in zip(args, param_names)]
         ret = c_with_virt.virtualized.call_transformed(*bound_args)
         ret = concrete_to_abstract(ret)
 
     name = c_with_virt.virtualized.get_function_name()
 
-    from argon.virtualization.virtualizer import get_inputs
-
-    body = Block[ret.A](get_inputs(scope.scope.symbols), scope.scope.symbols, ret)
+    body = Block[ret.A](scope_context.scope.inputs, scope_context.scope.symbols, ret)
 
     from argon.node.function_new import FunctionNew
 

--- a/src/argon/types/function.py
+++ b/src/argon/types/function.py
@@ -16,21 +16,21 @@ class FunctionWithVirt(Protocol):
     virtualized: ArgonFunction
 
 
-F = typing.TypeVar("F")
+RETURN_TP = typing.TypeVar("RETURN_TP")
 
 
-class Function[F](Ref[FunctionWithVirt, "Function[F]"]):
+class Function[RETURN_TP](Ref[FunctionWithVirt, "Function[RETURN_TP]"]):
     """
     The Function class represents a function in the Argon language.
     """
 
     @override
-    def fresh(self) -> "Function[F]":  # type: ignore -- Pyright falsely detects F as an abstractproperty instead of type variable
-        return Function[self.F]()
+    def fresh(self) -> "Function[RETURN_TP]":  # type: ignore -- Pyright falsely detects F as an abstractproperty instead of type variable
+        return Function[self.RETURN_TP]()
 
-    # F shim is used to silence typing errors -- its actual definition is provided by ArgonMeta
+    # RETURN_TP shim is used to silence typing errors -- its actual definition is provided by ArgonMeta
     @abc.abstractproperty
-    def F(self) -> typing.Type[F]:
+    def RETURN_TP(self) -> typing.Type[RETURN_TP]:
         raise NotImplementedError()
 
 

--- a/src/argon/types/integer.py
+++ b/src/argon/types/integer.py
@@ -4,6 +4,7 @@ from argon.node import arith
 from argon.ref import Ref
 from argon.srcctx import SrcCtx
 from argon.state import stage
+from argon.types.boolean import Boolean
 from argon.virtualization.type_mapper import concrete_to_abstract
 
 
@@ -22,7 +23,29 @@ class Integer(Ref[int, "Integer"]):
         return stage(arith.Add[Integer](self, other), ctx=SrcCtx.new(2))
 
     def __radd__(self, other: "Integer") -> "Integer":
-        return self + other
+        other = typing.cast(Integer, concrete_to_abstract(other))
+
+        return stage(arith.Add[Integer](other, self), ctx=SrcCtx.new(2))
+    
+    def __sub__(self, other: "Integer") -> "Integer":
+        other = typing.cast(Integer, concrete_to_abstract(other))
+
+        return stage(arith.Sub[Integer](self, other), ctx=SrcCtx.new(2))
+    
+    def __rsub__(self, other: "Integer") -> "Integer":
+        other = typing.cast(Integer, concrete_to_abstract(other))
+
+        return stage(arith.Sub[Integer](other, self), ctx=SrcCtx.new(2))
+    
+    def __gt__(self, other: "Integer") -> Boolean:
+        other = typing.cast(Integer, concrete_to_abstract(other))
+
+        return stage(arith.GreaterThan[Integer](self, other), ctx=SrcCtx.new(2))
+    
+    def __lt__(self, other: "Integer") -> Boolean:
+        other = typing.cast(Integer, concrete_to_abstract(other))
+
+        return stage(arith.LessThan[Integer](self, other), ctx=SrcCtx.new(2))
 
 
 concrete_to_abstract[int] = lambda x: Integer().const(x)

--- a/src/argon/types/struct.py
+++ b/src/argon/types/struct.py
@@ -1,3 +1,4 @@
+import abc
 from typing import override
 import typing
 from argon.ref import Ref
@@ -5,26 +6,32 @@ from argon.srcctx import SrcCtx
 from argon.state import stage
 
 
-T = typing.TypeVar("T")
+MEMBERS_TP = typing.TypeVar("MEMBERS_TP")
 
 
-class Struct[T](Ref[dict, "Struct[T]"]):
+class Struct[MEMBERS_TP](Ref[dict, "Struct[MEMBERS_TP]"]):
     """
-    The Struct[T] class represents a namedtuple in the Argon
-    language. The type parameter T is a namedtuple with keys
+    The Struct[MEMBERS_TP] class represents a namedtuple in the Argon
+    language. The type parameter MEMBERS_TP is a namedtuple with keys
     mapping to the types of the values in the NamedTuple.
     """
 
     @override
-    def fresh(self) -> "Struct[T]":
-        return Struct[self.T]()
+    def fresh(self) -> "Struct[MEMBERS_TP]":  # type: ignore -- Pyright falsely detects MEMBERS_TP as an abstractproperty instead of type variable
+        return Struct[self.MEMBERS_TP]()
+
+    # MEMBERS_TP shim is used to silence typing errors -- its actual definition is provided by ArgonMeta
+    @abc.abstractproperty
+    def MEMBERS_TP(self) -> typing.Type[MEMBERS_TP]:
+        raise NotImplementedError()
 
     # TODO: Only restricting keys to str for now
-    def __getitem__(self, key: str) -> T:
+    def __getitem__(self, key: str) -> MEMBERS_TP:  # type: ignore -- Pyright falsely detects MEMBERS_TP as an abstractproperty instead of type variable
         try:
-            item_tp = self.T[key]
+            item_tp = self.MEMBERS_TP[key]
         except KeyError:
             raise KeyError(f"Key '{key}' not found in dictionary {self}")
 
         from argon.node.struct_ops import Get
+
         return stage(Get[item_tp](self, key), ctx=SrcCtx.new(2))

--- a/src/argon/types/struct.py
+++ b/src/argon/types/struct.py
@@ -1,6 +1,5 @@
 from typing import override
 import typing
-from argon.node.dict_ops import Get
 from argon.ref import Ref
 from argon.srcctx import SrcCtx
 from argon.state import stage
@@ -9,16 +8,16 @@ from argon.state import stage
 T = typing.TypeVar("T")
 
 
-class Dictionary[T](Ref[dict, "Dictionary[T]"]):
+class Struct[T](Ref[dict, "Struct[T]"]):
     """
-    The NamedTuple[T] class represents a namedtuple in the Argon
+    The Struct[T] class represents a namedtuple in the Argon
     language. The type parameter T is a namedtuple with keys
     mapping to the types of the values in the NamedTuple.
     """
 
     @override
-    def fresh(self) -> "Dictionary[T]":
-        return Dictionary[self.T]()
+    def fresh(self) -> "Struct[T]":
+        return Struct[self.T]()
 
     # TODO: Only restricting keys to str for now
     def __getitem__(self, key: str) -> T:
@@ -26,4 +25,6 @@ class Dictionary[T](Ref[dict, "Dictionary[T]"]):
             item_tp = self.T[key]
         except KeyError:
             raise KeyError(f"Key '{key}' not found in dictionary {self}")
+
+        from argon.node.struct_ops import Get
         return stage(Get[item_tp](self, key), ctx=SrcCtx.new(2))

--- a/src/argon/virtualization/virtualizer.py
+++ b/src/argon/virtualization/virtualizer.py
@@ -92,11 +92,6 @@ def get_inputs(
     all_input_ids = set()
     for symbol in scope_symbols:
         inputs = symbol.rhs.val.underlying.inputs  # type: ignore -- symbol.rhs.val has already been checked to be a Node
-        inputs = [
-            input
-            for input in inputs
-            if input.is_node()
-        ]
         symbol_map.update({input.rhs.val.id: input for input in inputs})  # type: ignore -- input.rhs.val has already been checked to be a Node
         all_input_ids.update({input.rhs.val.id for input in inputs})  # type: ignore -- input.rhs.val has already been checked to be a Node
 

--- a/src/argon/virtualization/virtualizer.py
+++ b/src/argon/virtualization/virtualizer.py
@@ -276,6 +276,19 @@ class Transformer(ast.NodeTransformer):
 
         return node
 
+    def visit_AugAssign(self, node):
+        # Visit RHS of assignment
+        node.value = self.visit(node.value)
+
+        if isinstance(node.target, ast.Name):
+            self.variable_tracker.add_written_var(node.target.id)
+        else:
+            raise NotImplementedError(
+                "Only support single-variable assignments for augmented assignments"
+            )
+
+        return node
+
     def _process_target(self, target):
         # Handle simple variable assignment
         if isinstance(target, ast.Name):

--- a/src/argon/virtualization/virtualizer.py
+++ b/src/argon/virtualization/virtualizer.py
@@ -77,9 +77,7 @@ def get_inputs(
     scope_symbols = [
         symbol
         for symbol in scope_symbols
-        if symbol.rhs != None
-        and isinstance(symbol.rhs.val, Node)
-        and not isinstance(symbol.rhs.val.underlying, Phi)
+        if symbol.is_node() and not isinstance(symbol.rhs.val.underlying, Phi)
     ]
 
     # We use a symbol's id instead of just the symbol objects below because symbols
@@ -97,7 +95,7 @@ def get_inputs(
         inputs = [
             input
             for input in inputs
-            if input.rhs != None and isinstance(input.rhs.val, Node)
+            if input.is_node()
         ]
         symbol_map.update({input.rhs.val.id: input for input in inputs})  # type: ignore -- input.rhs.val has already been checked to be a Node
         all_input_ids.update({input.rhs.val.id for input in inputs})  # type: ignore -- input.rhs.val has already been checked to be a Node

--- a/src/argon/virtualization/virtualizer.py
+++ b/src/argon/virtualization/virtualizer.py
@@ -349,20 +349,20 @@ class Transformer(ast.NodeTransformer):
 
         # Recursively visit the then body
         self.assigned_vars = set()
+        self.loaded_vars = set()
         node.body = [self.visit(stmt) for stmt in node.body]
         then_assigned_vars = self.assigned_vars.copy()
         then_loaded_vars = self.loaded_vars.copy()
 
         # Recursively visit the else body
         self.assigned_vars = set()
+        self.loaded_vars = set()
         node.orelse = [self.visit(stmt) for stmt in node.orelse]
         else_assigned_vars = self.assigned_vars.copy()
         else_loaded_vars = self.loaded_vars.copy()
 
         # Merge the assigned variables found
-        self.assigned_vars = (
-            cond_assigned_vars | then_assigned_vars | else_assigned_vars
-        )
+        self.assigned_vars = cond_assigned_vars | then_assigned_vars | else_assigned_vars
         self.loaded_vars = cond_loaded_vars | then_loaded_vars | else_loaded_vars
         self.concrete_to_abstract_flag = prev_concrete_to_abstract_flag
 

--- a/src/argon/virtualization/virtualizer.py
+++ b/src/argon/virtualization/virtualizer.py
@@ -280,6 +280,17 @@ class Transformer(ast.NodeTransformer):
         else:
             raise NotImplementedError("Unsupported target type on LHS of assignment")
 
+    def visit_NamedExpr(self, node):
+        # Visit RHS of assignment
+        node.value = self.visit(node.value)
+
+        if isinstance(node.target, ast.Name):
+            self.variable_tracker.add_written_var(node.target.id)
+        else:
+            raise NotImplementedError("Only support single-variable assignments for walrus operators")
+
+        return node
+
     def visit_Break(self, node):
         raise NotImplementedError("Does not support break statements")
 

--- a/src/argon/virtualization/virtualizer/virtualizer_base.py
+++ b/src/argon/virtualization/virtualizer/virtualizer_base.py
@@ -14,8 +14,7 @@ class VariableTracker:
         return self.write_set_stack.pop(), self.read_set_stack.pop()
 
     def fold_context(self):
-        curr_read_set = self.read_set_stack.pop()
-        curr_write_set = self.write_set_stack.pop()
+        curr_write_set, curr_read_set = self.pop_context()
         self.current_read_set().update(curr_read_set - self.current_write_set())
         self.current_write_set().update(curr_write_set)
 

--- a/src/argon/virtualization/virtualizer/virtualizer_base.py
+++ b/src/argon/virtualization/virtualizer/virtualizer_base.py
@@ -1,0 +1,179 @@
+import ast
+
+
+class VariableTrackerWhile:
+    def __init__(self, variable_tracker: "VariableTracker"):
+        self.variable_tracker = variable_tracker
+
+    def __enter__(self):
+        self.variable_tracker.push_context()
+        self.variable_tracker.binds_stack.append(set())
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        popped_write_set, _ = self.variable_tracker.pop_context()
+        popped_binds = self.variable_tracker.binds_stack.pop()
+        for var in popped_write_set:
+            if var in popped_binds:
+                self.variable_tracker.add_read_var(var)
+            self.variable_tracker.add_written_var(var)
+
+    def add_written_var(self, var):
+        if (
+            (
+                len(self.variable_tracker.write_set_stack) > 1
+                and len(self.variable_tracker.read_set_stack) > 1
+            )
+            and (
+                var not in self.variable_tracker.current_write_set()
+                and var not in self.variable_tracker.previous_write_set()
+            )
+            and (
+                var in self.variable_tracker.current_read_set()
+                or var in self.variable_tracker.previous_read_set()
+            )
+        ):
+            self.variable_tracker.current_binds().add(var)
+
+
+class VariableTracker:
+    def __init__(self):
+        self.write_set_stack = [set()]
+        self.read_set_stack = [set()]
+        self.binds_stack = []
+        self.variable_tracker_while = VariableTrackerWhile(self)
+
+    def push_context(self):
+        self.write_set_stack.append(set())
+        self.read_set_stack.append(set())
+
+    def pop_context(self):
+        return self.write_set_stack.pop(), self.read_set_stack.pop()
+
+    def fold_context(self):
+        curr_write_set = self.write_set_stack.pop()
+        self.current_write_set().update(curr_write_set)
+        curr_read_set = self.read_set_stack.pop()
+        self.current_read_set().update(curr_read_set)
+
+    def current_write_set(self):
+        return self.write_set_stack[-1]
+
+    def previous_write_set(self):
+        return self.write_set_stack[-2]
+
+    def current_read_set(self):
+        return self.read_set_stack[-1]
+
+    def previous_read_set(self):
+        return self.read_set_stack[-2]
+
+    def current_binds(self):
+        return self.binds_stack[-1]
+
+    def add_written_var(self, var):
+        self.variable_tracker_while.add_written_var(var)
+        self.current_write_set().add(var)
+
+    def add_read_var(self, var):
+        self.current_read_set().add(var)
+
+
+class TransformerBase(ast.NodeTransformer):
+    def __init__(self, file_name, calls, ifs, if_exps, loops):
+        super().__init__()
+        self.counter = 0
+        self.unique_prefix = "__________"
+        self.file_name = file_name
+        self.calls = calls
+        self.ifs = ifs
+        self.if_exps = if_exps
+        self.loops = loops
+        self.concrete_to_abstract_flag = False
+        self.variable_tracker = VariableTracker()
+
+    def generate_temp_var(self, *args) -> str:
+        return self.unique_prefix + "_".join(args) + "_" + str(self.counter)
+
+    def concrete_to_abstract(self, node):
+        return ast.Call(
+            func=ast.Attribute(
+                value=ast.Attribute(
+                    value=ast.Attribute(
+                        value=ast.Attribute(
+                            value=ast.Name(id="__________argon", ctx=ast.Load()),
+                            attr="argon",
+                            ctx=ast.Load(),
+                        ),
+                        attr="virtualization",
+                        ctx=ast.Load(),
+                    ),
+                    attr="type_mapper",
+                    ctx=ast.Load(),
+                ),
+                attr="concrete_to_abstract",
+                ctx=ast.Load(),
+            ),
+            args=[node],
+            keywords=[],
+        )
+
+    def visit_Constant(self, node):
+        if self.concrete_to_abstract_flag:
+            return self.concrete_to_abstract(node)
+        return node
+
+    def visit_Name(self, node):
+        # Save the loaded variables
+        if isinstance(node.ctx, ast.Load):
+            self.variable_tracker.add_read_var(node.id)
+
+        if self.concrete_to_abstract_flag:
+            return self.concrete_to_abstract(node)
+        return node
+
+    def visit_Assign(self, node):
+        # Visit RHS of assignment
+        node.value = self.visit(node.value)
+
+        # Recursively process each target to extract all written variables
+        for target in node.targets:
+            self._process_target(target)
+
+        return node
+
+    def visit_AugAssign(self, node):
+        # Visit RHS of assignment
+        node.value = self.visit(node.value)
+
+        if isinstance(node.target, ast.Name):
+            self.variable_tracker.add_written_var(node.target.id)
+        else:
+            raise NotImplementedError(
+                "Only support single-variable assignments for augmented assignments"
+            )
+
+        return node
+
+    def _process_target(self, target):
+        # Handle simple variable assignment
+        if isinstance(target, ast.Name):
+            self.variable_tracker.add_written_var(target.id)
+        # Handle tuple or list unpacking
+        elif isinstance(target, (ast.Tuple, ast.List)):
+            for element in target.elts:
+                self._process_target(element)
+        else:
+            raise NotImplementedError("Unsupported target type on LHS of assignment")
+
+    def visit_NamedExpr(self, node):
+        # Visit RHS of assignment
+        node.value = self.visit(node.value)
+
+        if isinstance(node.target, ast.Name):
+            self.variable_tracker.add_written_var(node.target.id)
+        else:
+            raise NotImplementedError(
+                "Only support single-variable assignments for walrus operators"
+            )
+
+        return node

--- a/src/argon/virtualization/virtualizer/virtualizer_function_call.py
+++ b/src/argon/virtualization/virtualizer/virtualizer_function_call.py
@@ -22,7 +22,7 @@ def stage_function_call(
     abstract_args = [concrete_to_abstract(arg) for arg in args]
     abstract_func = concrete_to_abstract.function(func, abstract_args)
     return stage(
-        FunctionCall[abstract_func.F](abstract_func, abstract_args), ctx=SrcCtx.new(2)
+        FunctionCall[abstract_func.RETURN_TP](abstract_func, abstract_args), ctx=SrcCtx.new(2)
     )
 
 

--- a/src/argon/virtualization/virtualizer/virtualizer_function_call.py
+++ b/src/argon/virtualization/virtualizer/virtualizer_function_call.py
@@ -1,0 +1,78 @@
+import ast
+import types
+import typing
+
+from argon.node.function_call import FunctionCall
+from argon.ref import Ref
+from argon.srcctx import SrcCtx
+from argon.state import stage
+from argon.virtualization.virtualizer.virtualizer_base import TransformerBase
+from argon.virtualization.type_mapper import concrete_to_abstract
+
+
+def stage_function_call(
+    func: types.FunctionType, args: typing.List[typing.Any]
+) -> Ref[typing.Any, typing.Any]:
+    white_list = [
+        print
+    ]  # TODO: Add more whitelisted functions here that we don't want to stage
+    if func in white_list:
+        return func(*args)
+
+    abstract_args = [concrete_to_abstract(arg) for arg in args]
+    abstract_func = concrete_to_abstract.function(func, abstract_args)
+    return stage(
+        FunctionCall[abstract_func.F](abstract_func, abstract_args), ctx=SrcCtx.new(2)
+    )
+
+
+class TransformerFunctionCall(TransformerBase):
+    # This method is called for function calls
+    def visit_Call(self, node):
+        # Recursively visit arguments
+        prev_concrete_to_abstract_flag = self.concrete_to_abstract_flag
+        self.concrete_to_abstract_flag = False
+        self.generic_visit(node)
+        self.concrete_to_abstract_flag = prev_concrete_to_abstract_flag
+
+        # Do not stage the function call if the flag is set to False
+        if not self.calls:
+            if not self.concrete_to_abstract_flag:
+                return node
+            else:
+                return self.concrete_to_abstract(node)
+
+        # Wrap arguments in a list
+        args_list = ast.List(elts=node.args, ctx=ast.Load())
+
+        # Create the staged function call
+        staged_call = ast.Call(
+            func=ast.Attribute(
+                value=ast.Attribute(
+                    value=ast.Attribute(
+                        value=ast.Attribute(
+                            value=ast.Attribute(
+                                value=ast.Name(id="__________argon", ctx=ast.Load()),
+                                attr="argon",
+                                ctx=ast.Load(),
+                            ),
+                            attr="virtualization",
+                            ctx=ast.Load(),
+                        ),
+                        attr="virtualizer",
+                        ctx=ast.Load(),
+                    ),
+                    attr="virtualizer_function_call",
+                    ctx=ast.Load(),
+                ),
+                attr="stage_function_call",
+                ctx=ast.Load(),
+            ),
+            args=[node.func, args_list],
+            keywords=[],
+        )
+
+        # Attach source location (line numbers and column offsets)
+        ast.copy_location(staged_call, node)
+
+        return staged_call

--- a/src/argon/virtualization/virtualizer/virtualizer_ifthenelse.py
+++ b/src/argon/virtualization/virtualizer/virtualizer_ifthenelse.py
@@ -1,12 +1,9 @@
 import ast
-from collections import namedtuple
 import dis
-import types
 import typing
 
 from argon.block import Block
-from argon.node.control import IfThenElse, Loop
-from argon.node.function_call import FunctionCall
+from argon.node.control import IfThenElse
 from argon.node.phi import Phi
 from argon.node.undefined import Undefined
 from argon.ref import Exp, Ref
@@ -14,7 +11,7 @@ from argon.srcctx import SrcCtx
 from argon.state import ScopeContext, State, stage
 from argon.types.boolean import Boolean
 from argon.types.null import Null
-from argon.virtualization.type_mapper import concrete_to_abstract
+from argon.virtualization.virtualizer.virtualizer_base import TransformerBase
 
 
 def stage_undefined(name, T, file_name, lineno, col_offset):
@@ -98,273 +95,7 @@ def stage_if(
     )
 
 
-def stage_function_call(
-    func: types.FunctionType, args: typing.List[typing.Any]
-) -> Ref[typing.Any, typing.Any]:
-    white_list = [
-        print
-    ]  # TODO: Add more whitelisted functions here that we don't want to stage
-    if func in white_list:
-        return func(*args)
-
-    abstract_args = [concrete_to_abstract(arg) for arg in args]
-    abstract_func = concrete_to_abstract.function(func, abstract_args)
-    return stage(
-        FunctionCall[abstract_func.F](abstract_func, abstract_args), ctx=SrcCtx.new(2)
-    )
-
-
-def stage_loop(
-    file_name: str,
-    lineno: int,
-    col_offset: int,
-    values: typing.List[Exp[typing.Any, typing.Any]],
-    binds: typing.List[Exp[typing.Any, typing.Any]],
-    cond_scope_context: ScopeContext,
-    cond: Exp[typing.Any, typing.Any],
-    loop_scope_context: ScopeContext,
-    outputs: namedtuple,
-) -> Ref[typing.Any, typing.Any]:
-    condBlk = Block[Boolean](
-        cond_scope_context.scope.inputs, cond_scope_context.scope.symbols, cond
-    )
-    bodyBlk = Block[Null](
-        loop_scope_context.scope.inputs,
-        loop_scope_context.scope.symbols,
-        Null().const(None),
-    )
-    return stage(
-        Loop(values, binds, condBlk, bodyBlk, outputs),
-        ctx=SrcCtx(file_name, dis.Positions(lineno=lineno, col_offset=col_offset)),
-    )
-
-
-class VariableTrackerWhile:
-    def __init__(self, variable_tracker: "VariableTracker"):
-        self.variable_tracker = variable_tracker
-
-    def __enter__(self):
-        self.variable_tracker.push_context()
-        self.variable_tracker.binds_stack.append(set())
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        popped_write_set, _ = self.variable_tracker.pop_context()
-        popped_binds = self.variable_tracker.binds_stack.pop()
-        for var in popped_write_set:
-            if var in popped_binds:
-                self.variable_tracker.add_read_var(var)
-            self.variable_tracker.add_written_var(var)
-
-    def add_written_var(self, var):
-        if (
-            (
-                len(self.variable_tracker.write_set_stack) > 1
-                and len(self.variable_tracker.read_set_stack) > 1
-            )
-            and (
-                var not in self.variable_tracker.current_write_set()
-                and var not in self.variable_tracker.previous_write_set()
-            )
-            and (
-                var in self.variable_tracker.current_read_set()
-                or var in self.variable_tracker.previous_read_set()
-            )
-        ):
-            self.variable_tracker.current_binds().add(var)
-
-
-class VariableTracker:
-    def __init__(self):
-        self.write_set_stack = [set()]
-        self.read_set_stack = [set()]
-        self.binds_stack = []
-        self.variable_tracker_while = VariableTrackerWhile(self)
-
-    def push_context(self):
-        self.write_set_stack.append(set())
-        self.read_set_stack.append(set())
-
-    def pop_context(self):
-        return self.write_set_stack.pop(), self.read_set_stack.pop()
-
-    def fold_context(self):
-        curr_write_set = self.write_set_stack.pop()
-        self.current_write_set().update(curr_write_set)
-        curr_read_set = self.read_set_stack.pop()
-        self.current_read_set().update(curr_read_set)
-
-    def current_write_set(self):
-        return self.write_set_stack[-1]
-
-    def previous_write_set(self):
-        return self.write_set_stack[-2]
-
-    def current_read_set(self):
-        return self.read_set_stack[-1]
-
-    def previous_read_set(self):
-        return self.read_set_stack[-2]
-
-    def current_binds(self):
-        return self.binds_stack[-1]
-
-    def add_written_var(self, var):
-        self.variable_tracker_while.add_written_var(var)
-        self.current_write_set().add(var)
-
-    def add_read_var(self, var):
-        self.current_read_set().add(var)
-
-
-class Transformer(ast.NodeTransformer):
-    def __init__(self, file_name, calls, ifs, if_exps, loops):
-        super().__init__()
-        self.counter = 0
-        self.unique_prefix = "__________"
-        self.file_name = file_name
-        self.calls = calls
-        self.ifs = ifs
-        self.if_exps = if_exps
-        self.loops = loops
-        self.concrete_to_abstract_flag = False
-        self.variable_tracker = VariableTracker()
-
-    def concrete_to_abstract(self, node):
-        return ast.Call(
-            func=ast.Attribute(
-                value=ast.Attribute(
-                    value=ast.Attribute(
-                        value=ast.Attribute(
-                            value=ast.Name(id="__________argon", ctx=ast.Load()),
-                            attr="argon",
-                            ctx=ast.Load(),
-                        ),
-                        attr="virtualization",
-                        ctx=ast.Load(),
-                    ),
-                    attr="type_mapper",
-                    ctx=ast.Load(),
-                ),
-                attr="concrete_to_abstract",
-                ctx=ast.Load(),
-            ),
-            args=[node],
-            keywords=[],
-        )
-
-    def visit_Constant(self, node):
-        if self.concrete_to_abstract_flag:
-            return self.concrete_to_abstract(node)
-        return node
-
-    def visit_Name(self, node):
-        # Save the loaded variables
-        if isinstance(node.ctx, ast.Load):
-            self.variable_tracker.add_read_var(node.id)
-
-        if self.concrete_to_abstract_flag:
-            return self.concrete_to_abstract(node)
-        return node
-
-    def visit_Assign(self, node):
-        # Visit RHS of assignment
-        node.value = self.visit(node.value)
-
-        # Recursively process each target to extract all written variables
-        for target in node.targets:
-            self._process_target(target)
-
-        return node
-
-    def visit_AugAssign(self, node):
-        # Visit RHS of assignment
-        node.value = self.visit(node.value)
-
-        if isinstance(node.target, ast.Name):
-            self.variable_tracker.add_written_var(node.target.id)
-        else:
-            raise NotImplementedError(
-                "Only support single-variable assignments for augmented assignments"
-            )
-
-        return node
-
-    def _process_target(self, target):
-        # Handle simple variable assignment
-        if isinstance(target, ast.Name):
-            self.variable_tracker.add_written_var(target.id)
-        # Handle tuple or list unpacking
-        elif isinstance(target, (ast.Tuple, ast.List)):
-            for element in target.elts:
-                self._process_target(element)
-        else:
-            raise NotImplementedError("Unsupported target type on LHS of assignment")
-
-    def visit_NamedExpr(self, node):
-        # Visit RHS of assignment
-        node.value = self.visit(node.value)
-
-        if isinstance(node.target, ast.Name):
-            self.variable_tracker.add_written_var(node.target.id)
-        else:
-            raise NotImplementedError(
-                "Only support single-variable assignments for walrus operators"
-            )
-
-        return node
-
-    def visit_Break(self, node):
-        raise NotImplementedError("Does not support break statements")
-
-    def visit_Continue(self, node):
-        raise NotImplementedError("Does not support continue statements")
-
-    # This method is called for function calls
-    def visit_Call(self, node):
-        # Recursively visit arguments
-        prev_concrete_to_abstract_flag = self.concrete_to_abstract_flag
-        self.concrete_to_abstract_flag = False
-        self.generic_visit(node)
-        self.concrete_to_abstract_flag = prev_concrete_to_abstract_flag
-
-        # Do not stage the function call if the flag is set to False
-        if not self.calls:
-            if not self.concrete_to_abstract_flag:
-                return node
-            else:
-                return self.concrete_to_abstract(node)
-
-        # Wrap arguments in a list
-        args_list = ast.List(elts=node.args, ctx=ast.Load())
-
-        # Create the staged function call
-        staged_call = ast.Call(
-            func=ast.Attribute(
-                value=ast.Attribute(
-                    value=ast.Attribute(
-                        value=ast.Attribute(
-                            value=ast.Name(id="__________argon", ctx=ast.Load()),
-                            attr="argon",
-                            ctx=ast.Load(),
-                        ),
-                        attr="virtualization",
-                        ctx=ast.Load(),
-                    ),
-                    attr="virtualizer",
-                    ctx=ast.Load(),
-                ),
-                attr="stage_function_call",
-                ctx=ast.Load(),
-            ),
-            args=[node.func, args_list],
-            keywords=[],
-        )
-
-        # Attach source location (line numbers and column offsets)
-        ast.copy_location(staged_call, node)
-
-        return staged_call
-
+class TransformerIfThenElse(TransformerBase):
     # This method is called for ternary "if" expressions
     def visit_IfExp(self, node):
         # Recursively visit the condition, the then case, and the else case
@@ -386,14 +117,18 @@ class Transformer(ast.NodeTransformer):
                 value=ast.Attribute(
                     value=ast.Attribute(
                         value=ast.Attribute(
-                            value=ast.Name(id="__________argon", ctx=ast.Load()),
-                            attr="argon",
+                            value=ast.Attribute(
+                                value=ast.Name(id="__________argon", ctx=ast.Load()),
+                                attr="argon",
+                                ctx=ast.Load(),
+                            ),
+                            attr="virtualization",
                             ctx=ast.Load(),
                         ),
-                        attr="virtualization",
+                        attr="virtualizer",
                         ctx=ast.Load(),
                     ),
-                    attr="virtualizer",
+                    attr="virtualizer_ifthenelse",
                     ctx=ast.Load(),
                 ),
                 attr="stage_if_exp_with_scopes",
@@ -507,7 +242,7 @@ try:
     {temp_var} = lambda _, {var} = {var}: __________argon.argon.virtualization.type_mapper.concrete_to_abstract({var})
     {temp_var_exists} = True
 except NameError:
-    {temp_var} = lambda T : __________argon.argon.virtualization.virtualizer.stage_undefined('{var}', T, '{self.file_name}', {node.lineno}, {node.col_offset})
+    {temp_var} = lambda T : __________argon.argon.virtualization.virtualizer.virtualizer_ifthenelse.stage_undefined('{var}', T, '{self.file_name}', {node.lineno}, {node.col_offset})
     {temp_var_exists} = False
 """
                 ).body
@@ -665,7 +400,7 @@ except NameError:
         # Stage if call
         new_body.extend(
             ast.parse(
-                f"__________argon.argon.virtualization.virtualizer.stage_if('{self.file_name}', {node.lineno}, {node.col_offset}, {cond_scope_name}, {cond_name}, {then_scope_name}, {else_scope_name})"
+                f"__________argon.argon.virtualization.virtualizer.virtualizer_ifthenelse.stage_if('{self.file_name}', {node.lineno}, {node.col_offset}, {cond_scope_name}, {cond_name}, {then_scope_name}, {else_scope_name})"
             ).body
         )
 
@@ -675,7 +410,7 @@ except NameError:
             temp_var_else = self.generate_temp_var(var, "else")
             new_body.extend(
                 ast.parse(
-                    f"{var} = __________argon.argon.virtualization.virtualizer.stage_phi({cond_name}, {temp_var_then}, {temp_var_else})"
+                    f"{var} = __________argon.argon.virtualization.virtualizer.virtualizer_ifthenelse.stage_phi({cond_name}, {temp_var_then}, {temp_var_else})"
                 ).body
             )
 
@@ -724,183 +459,7 @@ except NameError:
         self.variable_tracker.fold_context()
 
         return node
-
-    def visit_While(self, node):
-        with self.variable_tracker.variable_tracker_while:
-            # Increment counter to ensure unique names for this while loop
-            self.counter += 1
-
-            # Properly set flags before recursive visits
-            prev_concrete_to_abstract_flag = self.concrete_to_abstract_flag
-            self.concrete_to_abstract_flag = self.loops
-
-            # Recursively visit the condition
-            self.variable_tracker.push_context()
-            node.test = self.visit(node.test)
-            cond_write_set = self.variable_tracker.current_write_set()
-            cond_read_set = self.variable_tracker.current_read_set()
-            self.variable_tracker.fold_context()
-
-            # Recursively visit the body
-            self.variable_tracker.push_context()
-            node.body = [self.visit(stmt) for stmt in node.body]
-            body_write_set = self.variable_tracker.current_write_set()
-            body_read_set = self.variable_tracker.current_read_set()
-            self.variable_tracker.fold_context()
-
-            if node.orelse:
-                raise NotImplementedError("Does not support else statements for loops")
-
-            new_body: typing.List[ast.stmt] = []
-
-            # Create temporary list of input values and binds
-            values_name = self.generate_temp_var("values")
-            binds_name = self.generate_temp_var("binds")
-            new_body.append(
-                ast.Assign(
-                    targets=[ast.Name(id=values_name, ctx=ast.Store())],
-                    value=ast.List(elts=[], ctx=ast.Load()),
-                )
-            )
-            new_body.append(
-                ast.Assign(
-                    targets=[ast.Name(id=binds_name, ctx=ast.Store())],
-                    value=ast.List(elts=[], ctx=ast.Load()),
-                )
-            )
-
-            # Create binds
-            # TODO: This part needs to be changed to only create binds for inputs
-            for var in self.variable_tracker.current_binds():
-                new_body.extend(
-                    ast.parse(
-                        f"""
-try:
-    {values_name}.append(__________argon.argon.virtualization.type_mapper.concrete_to_abstract({var}))
-    {var} = __________argon.argon.virtualization.type_mapper.concrete_to_abstract({var}).bound('{var}')
-    {binds_name}.append({var})
-except NameError:
-    pass
-"""
-                    ).body
-                )
-
-            # Run the condition under a different scope
-            cond_scope_name = self.generate_temp_var("cond", "scope")
-            cond_name = self.generate_temp_var("cond")
-            new_body.extend(
-                ast.parse(
-                    f"{cond_scope_name} = __________argon.argon.state.State.get_current_state().new_scope()"
-                ).body
-            )
-            new_body.append(
-                ast.With(
-                    items=[
-                        ast.withitem(
-                            context_expr=ast.Name(id=cond_scope_name, ctx=ast.Load())
-                        )
-                    ],
-                    body=[
-                        ast.Assign(
-                            targets=[ast.Name(id=cond_name, ctx=ast.Store())],
-                            value=node.test,
-                        )
-                    ],
-                )
-            )
-
-            # Create a new scope to run the loop body
-            loop_scope_name = self.generate_temp_var("loop", "scope")
-            new_body.extend(
-                ast.parse(
-                    f"{loop_scope_name} = __________argon.argon.state.State.get_current_state().new_scope()"
-                ).body
-            )
-            loop_outputs_name = self.generate_temp_var("loop", "outputs")
-            loop_body = node.body.copy()
-            loop_body.append(  # The loop body should be the original loop body + the following line to assign the loop outputs
-                ast.Assign(
-                    targets=[ast.Name(id=loop_outputs_name, ctx=ast.Store())],
-                    value=ast.Call(
-                        func=ast.Call(
-                            func=ast.Name(id="namedtuple", ctx=ast.Load()),
-                            args=[
-                                ast.Constant(value=loop_outputs_name),
-                                ast.List(
-                                    elts=[
-                                        ast.Constant(value=var)
-                                        for var in self.variable_tracker.current_write_set()
-                                    ],
-                                    ctx=ast.Load(),
-                                ),
-                            ],
-                            keywords=[],
-                        ),
-                        args=[
-                            ast.Name(id=var, ctx=ast.Load())
-                            for var in self.variable_tracker.current_write_set()
-                        ],
-                        keywords=[],
-                    ),
-                )
-            )
-            new_body.append(
-                ast.With(
-                    items=[
-                        ast.withitem(
-                            context_expr=ast.Name(id=loop_scope_name, ctx=ast.Load())
-                        )
-                    ],
-                    body=loop_body,
-                )
-            )
-
-            # Stage the loop
-            new_body.extend(
-                ast.parse(
-                    f"__________argon.argon.virtualization.virtualizer.stage_loop('{self.file_name}', {node.lineno}, {node.col_offset}, {values_name}, {binds_name}, {cond_scope_name}, {cond_name}, {loop_scope_name}, {loop_outputs_name})"
-                ).body
-            )
-
-            # Delete all temporary variables
-            # TODO: COMPLETE THIS PART
-            new_body.append(
-                ast.Delete(targets=[ast.Name(id=values_name, ctx=ast.Del())])
-            )
-            new_body.append(
-                ast.Delete(targets=[ast.Name(id=binds_name, ctx=ast.Del())])
-            )
-            new_body.append(
-                ast.Delete(targets=[ast.Name(id=cond_scope_name, ctx=ast.Del())])
-            )
-            new_body.append(ast.Delete(targets=[ast.Name(id=cond_name, ctx=ast.Del())]))
-            new_body.append(
-                ast.Delete(targets=[ast.Name(id=loop_scope_name, ctx=ast.Del())])
-            )
-            new_body.append(
-                ast.Delete(targets=[ast.Name(id=loop_outputs_name, ctx=ast.Del())])
-            )
-
-            new_body.append(ast.Break())
-
-            # Do not stage the while loop if the flag is set to False
-            # TODO: error handling if condition is Argon type
-            if self.loops:
-                # Replace the original while body with the new wrapped body
-                node.body = new_body
-
-                # Set the condition to True and add a break statement at the end of the body
-                # This lets us run the body just once
-                node.test = ast.Constant(value=True)
-
-            self.counter -= 1
-            self.concrete_to_abstract_flag = prev_concrete_to_abstract_flag
-
-        return node
-
-    def generate_temp_var(self, *args) -> str:
-        return self.unique_prefix + "_".join(args) + "_" + str(self.counter)
-
+    
     def modify_body(
         self, body: typing.List[ast.stmt], scope_name: str, vars: set
     ) -> list:

--- a/src/argon/virtualization/virtualizer/virtualizer_loop.py
+++ b/src/argon/virtualization/virtualizer/virtualizer_loop.py
@@ -1,0 +1,219 @@
+import ast
+from collections import namedtuple
+import dis
+import typing
+
+from argon.block import Block
+from argon.node.control import Loop
+from argon.ref import Exp, Ref
+from argon.srcctx import SrcCtx
+from argon.state import ScopeContext, stage
+from argon.types.boolean import Boolean
+from argon.types.null import Null
+from argon.virtualization.virtualizer.virtualizer_base import TransformerBase
+
+
+def stage_loop(
+    file_name: str,
+    lineno: int,
+    col_offset: int,
+    values: typing.List[Exp[typing.Any, typing.Any]],
+    binds: typing.List[Exp[typing.Any, typing.Any]],
+    cond_scope_context: ScopeContext,
+    cond: Exp[typing.Any, typing.Any],
+    loop_scope_context: ScopeContext,
+    outputs: namedtuple,
+) -> Ref[typing.Any, typing.Any]:
+    condBlk = Block[Boolean](
+        cond_scope_context.scope.inputs, cond_scope_context.scope.symbols, cond
+    )
+    bodyBlk = Block[Null](
+        loop_scope_context.scope.inputs,
+        loop_scope_context.scope.symbols,
+        Null().const(None),
+    )
+    return stage(
+        Loop(values, binds, condBlk, bodyBlk, outputs),
+        ctx=SrcCtx(file_name, dis.Positions(lineno=lineno, col_offset=col_offset)),
+    )
+
+
+class TransformerLoop(TransformerBase):
+    def visit_Break(self, node):
+        raise NotImplementedError("Does not support break statements")
+
+    def visit_Continue(self, node):
+        raise NotImplementedError("Does not support continue statements")
+
+    def visit_While(self, node):
+        with self.variable_tracker.variable_tracker_while:
+            # Increment counter to ensure unique names for this while loop
+            self.counter += 1
+
+            # Properly set flags before recursive visits
+            prev_concrete_to_abstract_flag = self.concrete_to_abstract_flag
+            self.concrete_to_abstract_flag = self.loops
+
+            # Recursively visit the condition
+            self.variable_tracker.push_context()
+            node.test = self.visit(node.test)
+            cond_write_set = self.variable_tracker.current_write_set()
+            cond_read_set = self.variable_tracker.current_read_set()
+            self.variable_tracker.fold_context()
+
+            # Recursively visit the body
+            self.variable_tracker.push_context()
+            node.body = [self.visit(stmt) for stmt in node.body]
+            body_write_set = self.variable_tracker.current_write_set()
+            body_read_set = self.variable_tracker.current_read_set()
+            self.variable_tracker.fold_context()
+
+            if node.orelse:
+                raise NotImplementedError("Does not support else statements for loops")
+
+            new_body: typing.List[ast.stmt] = []
+
+            # Create temporary list of input values and binds
+            values_name = self.generate_temp_var("values")
+            binds_name = self.generate_temp_var("binds")
+            new_body.append(
+                ast.Assign(
+                    targets=[ast.Name(id=values_name, ctx=ast.Store())],
+                    value=ast.List(elts=[], ctx=ast.Load()),
+                )
+            )
+            new_body.append(
+                ast.Assign(
+                    targets=[ast.Name(id=binds_name, ctx=ast.Store())],
+                    value=ast.List(elts=[], ctx=ast.Load()),
+                )
+            )
+
+            # Create binds
+            # TODO: This part needs to be changed to only create binds for inputs
+            for var in self.variable_tracker.current_binds():
+                new_body.extend(
+                    ast.parse(
+                        f"""
+try:
+    {values_name}.append(__________argon.argon.virtualization.type_mapper.concrete_to_abstract({var}))
+    {var} = __________argon.argon.virtualization.type_mapper.concrete_to_abstract({var}).bound('{var}')
+    {binds_name}.append({var})
+except NameError:
+    pass
+"""
+                    ).body
+                )
+
+            # Run the condition under a different scope
+            cond_scope_name = self.generate_temp_var("cond", "scope")
+            cond_name = self.generate_temp_var("cond")
+            new_body.extend(
+                ast.parse(
+                    f"{cond_scope_name} = __________argon.argon.state.State.get_current_state().new_scope()"
+                ).body
+            )
+            new_body.append(
+                ast.With(
+                    items=[
+                        ast.withitem(
+                            context_expr=ast.Name(id=cond_scope_name, ctx=ast.Load())
+                        )
+                    ],
+                    body=[
+                        ast.Assign(
+                            targets=[ast.Name(id=cond_name, ctx=ast.Store())],
+                            value=node.test,
+                        )
+                    ],
+                )
+            )
+
+            # Create a new scope to run the loop body
+            loop_scope_name = self.generate_temp_var("loop", "scope")
+            new_body.extend(
+                ast.parse(
+                    f"{loop_scope_name} = __________argon.argon.state.State.get_current_state().new_scope()"
+                ).body
+            )
+            loop_outputs_name = self.generate_temp_var("loop", "outputs")
+            loop_body = node.body.copy()
+            loop_body.append(  # The loop body should be the original loop body + the following line to assign the loop outputs
+                ast.Assign(
+                    targets=[ast.Name(id=loop_outputs_name, ctx=ast.Store())],
+                    value=ast.Call(
+                        func=ast.Call(
+                            func=ast.Name(id="namedtuple", ctx=ast.Load()),
+                            args=[
+                                ast.Constant(value=loop_outputs_name),
+                                ast.List(
+                                    elts=[
+                                        ast.Constant(value=var)
+                                        for var in self.variable_tracker.current_write_set()
+                                    ],
+                                    ctx=ast.Load(),
+                                ),
+                            ],
+                            keywords=[],
+                        ),
+                        args=[
+                            ast.Name(id=var, ctx=ast.Load())
+                            for var in self.variable_tracker.current_write_set()
+                        ],
+                        keywords=[],
+                    ),
+                )
+            )
+            new_body.append(
+                ast.With(
+                    items=[
+                        ast.withitem(
+                            context_expr=ast.Name(id=loop_scope_name, ctx=ast.Load())
+                        )
+                    ],
+                    body=loop_body,
+                )
+            )
+
+            # Stage the loop
+            new_body.extend(
+                ast.parse(
+                    f"__________argon.argon.virtualization.virtualizer.virtualizer_loop.stage_loop('{self.file_name}', {node.lineno}, {node.col_offset}, {values_name}, {binds_name}, {cond_scope_name}, {cond_name}, {loop_scope_name}, {loop_outputs_name})"
+                ).body
+            )
+
+            # Delete all temporary variables
+            # TODO: COMPLETE THIS PART
+            new_body.append(
+                ast.Delete(targets=[ast.Name(id=values_name, ctx=ast.Del())])
+            )
+            new_body.append(
+                ast.Delete(targets=[ast.Name(id=binds_name, ctx=ast.Del())])
+            )
+            new_body.append(
+                ast.Delete(targets=[ast.Name(id=cond_scope_name, ctx=ast.Del())])
+            )
+            new_body.append(ast.Delete(targets=[ast.Name(id=cond_name, ctx=ast.Del())]))
+            new_body.append(
+                ast.Delete(targets=[ast.Name(id=loop_scope_name, ctx=ast.Del())])
+            )
+            new_body.append(
+                ast.Delete(targets=[ast.Name(id=loop_outputs_name, ctx=ast.Del())])
+            )
+
+            new_body.append(ast.Break())
+
+            # Do not stage the while loop if the flag is set to False
+            # TODO: error handling if condition is Argon type
+            if self.loops:
+                # Replace the original while body with the new wrapped body
+                node.body = new_body
+
+                # Set the condition to True and add a break statement at the end of the body
+                # This lets us run the body just once
+                node.test = ast.Constant(value=True)
+
+            self.counter -= 1
+            self.concrete_to_abstract_flag = prev_concrete_to_abstract_flag
+
+        return node

--- a/src/argon/virtualization/virtualizer/virtualizer_loop.py
+++ b/src/argon/virtualization/virtualizer/virtualizer_loop.py
@@ -99,12 +99,9 @@ class TransformerLoop(TransformerBase):
             new_body.extend(
                 ast.parse(
                     f"""
-try:
-    {values_name}.append(__________argon.argon.virtualization.type_mapper.concrete_to_abstract({var}))
-    {var} = __________argon.argon.virtualization.type_mapper.concrete_to_abstract({var}).bound('{var}')
-    {binds_name}.append({var})
-except NameError:
-    pass
+{values_name}.append(__________argon.argon.virtualization.type_mapper.concrete_to_abstract({var}))
+{var} = __________argon.argon.virtualization.type_mapper.concrete_to_abstract({var}).bound('{var}')
+{binds_name}.append({var})
 """
                 ).body
             )

--- a/src/argon/virtualization/virtualizer/virtualizer_loop.py
+++ b/src/argon/virtualization/virtualizer/virtualizer_loop.py
@@ -46,55 +46,54 @@ class TransformerLoop(TransformerBase):
         raise NotImplementedError("Does not support continue statements")
 
     def visit_While(self, node):
-        with self.variable_tracker.variable_tracker_while:
-            # Increment counter to ensure unique names for this while loop
-            self.counter += 1
+        # Increment counter to ensure unique names for this while loop
+        self.counter += 1
 
-            # Properly set flags before recursive visits
-            prev_concrete_to_abstract_flag = self.concrete_to_abstract_flag
-            self.concrete_to_abstract_flag = self.loops
+        # Properly set flags before recursive visits
+        prev_concrete_to_abstract_flag = self.concrete_to_abstract_flag
+        self.concrete_to_abstract_flag = self.loops
 
-            # Recursively visit the condition
-            self.variable_tracker.push_context()
-            node.test = self.visit(node.test)
-            cond_write_set = self.variable_tracker.current_write_set()
-            cond_read_set = self.variable_tracker.current_read_set()
-            self.variable_tracker.fold_context()
+        # Recursively visit the condition
+        self.variable_tracker.push_context()
+        node.test = self.visit(node.test)
+        cond_write_set = self.variable_tracker.current_write_set()
+        cond_read_set = self.variable_tracker.current_read_set()
+        self.variable_tracker.fold_context()
 
-            # Recursively visit the body
-            self.variable_tracker.push_context()
-            node.body = [self.visit(stmt) for stmt in node.body]
-            body_write_set = self.variable_tracker.current_write_set()
-            body_read_set = self.variable_tracker.current_read_set()
-            self.variable_tracker.fold_context()
+        # Recursively visit the body
+        self.variable_tracker.push_context()
+        node.body = [self.visit(stmt) for stmt in node.body]
+        body_write_set = self.variable_tracker.current_write_set()
+        body_read_set = self.variable_tracker.current_read_set()
+        self.variable_tracker.fold_context()
 
-            if node.orelse:
-                raise NotImplementedError("Does not support else statements for loops")
+        if node.orelse:
+            raise NotImplementedError("Does not support else statements for loops")
 
-            new_body: typing.List[ast.stmt] = []
+        new_body: typing.List[ast.stmt] = []
 
-            # Create temporary list of input values and binds
-            values_name = self.generate_temp_var("values")
-            binds_name = self.generate_temp_var("binds")
-            new_body.append(
-                ast.Assign(
-                    targets=[ast.Name(id=values_name, ctx=ast.Store())],
-                    value=ast.List(elts=[], ctx=ast.Load()),
-                )
+        # Create temporary list of input values and binds
+        values_name = self.generate_temp_var("values")
+        binds_name = self.generate_temp_var("binds")
+        new_body.append(
+            ast.Assign(
+                targets=[ast.Name(id=values_name, ctx=ast.Store())],
+                value=ast.List(elts=[], ctx=ast.Load()),
             )
-            new_body.append(
-                ast.Assign(
-                    targets=[ast.Name(id=binds_name, ctx=ast.Store())],
-                    value=ast.List(elts=[], ctx=ast.Load()),
-                )
+        )
+        new_body.append(
+            ast.Assign(
+                targets=[ast.Name(id=binds_name, ctx=ast.Store())],
+                value=ast.List(elts=[], ctx=ast.Load()),
             )
+        )
 
-            # Create binds
-            # TODO: This part needs to be changed to only create binds for inputs
-            for var in self.variable_tracker.current_binds():
-                new_body.extend(
-                    ast.parse(
-                        f"""
+        # Create binds
+        # TODO: This part needs to be changed to only create binds for inputs
+        for var in (self.variable_tracker.current_write_set() & self.variable_tracker.current_read_set()):
+            new_body.extend(
+                ast.parse(
+                    f"""
 try:
     {values_name}.append(__________argon.argon.virtualization.type_mapper.concrete_to_abstract({var}))
     {var} = __________argon.argon.virtualization.type_mapper.concrete_to_abstract({var}).bound('{var}')
@@ -102,118 +101,118 @@ try:
 except NameError:
     pass
 """
-                    ).body
-                )
-
-            # Run the condition under a different scope
-            cond_scope_name = self.generate_temp_var("cond", "scope")
-            cond_name = self.generate_temp_var("cond")
-            new_body.extend(
-                ast.parse(
-                    f"{cond_scope_name} = __________argon.argon.state.State.get_current_state().new_scope()"
                 ).body
             )
-            new_body.append(
-                ast.With(
-                    items=[
-                        ast.withitem(
-                            context_expr=ast.Name(id=cond_scope_name, ctx=ast.Load())
-                        )
-                    ],
-                    body=[
-                        ast.Assign(
-                            targets=[ast.Name(id=cond_name, ctx=ast.Store())],
-                            value=node.test,
-                        )
-                    ],
-                )
-            )
 
-            # Create a new scope to run the loop body
-            loop_scope_name = self.generate_temp_var("loop", "scope")
-            new_body.extend(
-                ast.parse(
-                    f"{loop_scope_name} = __________argon.argon.state.State.get_current_state().new_scope()"
-                ).body
+        # Run the condition under a different scope
+        cond_scope_name = self.generate_temp_var("cond", "scope")
+        cond_name = self.generate_temp_var("cond")
+        new_body.extend(
+            ast.parse(
+                f"{cond_scope_name} = __________argon.argon.state.State.get_current_state().new_scope()"
+            ).body
+        )
+        new_body.append(
+            ast.With(
+                items=[
+                    ast.withitem(
+                        context_expr=ast.Name(id=cond_scope_name, ctx=ast.Load())
+                    )
+                ],
+                body=[
+                    ast.Assign(
+                        targets=[ast.Name(id=cond_name, ctx=ast.Store())],
+                        value=node.test,
+                    )
+                ],
             )
-            loop_outputs_name = self.generate_temp_var("loop", "outputs")
-            loop_body = node.body.copy()
-            loop_body.append(  # The loop body should be the original loop body + the following line to assign the loop outputs
-                ast.Assign(
-                    targets=[ast.Name(id=loop_outputs_name, ctx=ast.Store())],
-                    value=ast.Call(
-                        func=ast.Call(
-                            func=ast.Name(id="namedtuple", ctx=ast.Load()),
-                            args=[
-                                ast.Constant(value=loop_outputs_name),
-                                ast.List(
-                                    elts=[
-                                        ast.Constant(value=var)
-                                        for var in self.variable_tracker.current_write_set()
-                                    ],
-                                    ctx=ast.Load(),
-                                ),
-                            ],
-                            keywords=[],
-                        ),
+        )
+
+        # Create a new scope to run the loop body
+        loop_scope_name = self.generate_temp_var("loop", "scope")
+        new_body.extend(
+            ast.parse(
+                f"{loop_scope_name} = __________argon.argon.state.State.get_current_state().new_scope()"
+            ).body
+        )
+        loop_outputs_name = self.generate_temp_var("loop", "outputs")
+        loop_body = node.body.copy()
+        loop_body.append(  # The loop body should be the original loop body + the following line to assign the loop outputs
+            ast.Assign(
+                targets=[ast.Name(id=loop_outputs_name, ctx=ast.Store())],
+                value=ast.Call(
+                    func=ast.Call(
+                        func=ast.Name(id="namedtuple", ctx=ast.Load()),
                         args=[
-                            ast.Name(id=var, ctx=ast.Load())
-                            for var in self.variable_tracker.current_write_set()
+                            ast.Constant(value=loop_outputs_name),
+                            ast.List(
+                                elts=[
+                                    ast.Constant(value=var)
+                                    for var in self.variable_tracker.current_write_set()
+                                ],
+                                ctx=ast.Load(),
+                            ),
                         ],
                         keywords=[],
                     ),
-                )
-            )
-            new_body.append(
-                ast.With(
-                    items=[
-                        ast.withitem(
-                            context_expr=ast.Name(id=loop_scope_name, ctx=ast.Load())
-                        )
+                    args=[
+                        ast.Name(id=var, ctx=ast.Load())
+                        for var in self.variable_tracker.current_write_set()
                     ],
-                    body=loop_body,
-                )
+                    keywords=[],
+                ),
             )
+        )
+        new_body.append(
+            ast.With(
+                items=[
+                    ast.withitem(
+                        context_expr=ast.Name(id=loop_scope_name, ctx=ast.Load())
+                    )
+                ],
+                body=loop_body,
+            )
+        )
 
-            # Stage the loop
-            new_body.extend(
-                ast.parse(
-                    f"__________argon.argon.virtualization.virtualizer.virtualizer_loop.stage_loop('{self.file_name}', {node.lineno}, {node.col_offset}, {values_name}, {binds_name}, {cond_scope_name}, {cond_name}, {loop_scope_name}, {loop_outputs_name})"
-                ).body
-            )
+        # Stage the loop
+        new_body.extend(
+            ast.parse(
+                f"__________argon.argon.virtualization.virtualizer.virtualizer_loop.stage_loop('{self.file_name}', {node.lineno}, {node.col_offset}, {values_name}, {binds_name}, {cond_scope_name}, {cond_name}, {loop_scope_name}, {loop_outputs_name})"
+            ).body
+        )
 
-            # Delete all temporary variables
-            # TODO: COMPLETE THIS PART
-            new_body.append(
-                ast.Delete(targets=[ast.Name(id=values_name, ctx=ast.Del())])
-            )
-            new_body.append(
-                ast.Delete(targets=[ast.Name(id=binds_name, ctx=ast.Del())])
-            )
-            new_body.append(
-                ast.Delete(targets=[ast.Name(id=cond_scope_name, ctx=ast.Del())])
-            )
-            new_body.append(ast.Delete(targets=[ast.Name(id=cond_name, ctx=ast.Del())]))
-            new_body.append(
-                ast.Delete(targets=[ast.Name(id=loop_scope_name, ctx=ast.Del())])
-            )
-            new_body.append(
-                ast.Delete(targets=[ast.Name(id=loop_outputs_name, ctx=ast.Del())])
-            )
+        # Delete all temporary variables
+        # TODO: COMPLETE THIS PART
+        new_body.append(
+            ast.Delete(targets=[ast.Name(id=values_name, ctx=ast.Del())])
+        )
+        new_body.append(
+            ast.Delete(targets=[ast.Name(id=binds_name, ctx=ast.Del())])
+        )
+        new_body.append(
+            ast.Delete(targets=[ast.Name(id=cond_scope_name, ctx=ast.Del())])
+        )
+        new_body.append(ast.Delete(targets=[ast.Name(id=cond_name, ctx=ast.Del())]))
+        new_body.append(
+            ast.Delete(targets=[ast.Name(id=loop_scope_name, ctx=ast.Del())])
+        )
+        new_body.append(
+            ast.Delete(targets=[ast.Name(id=loop_outputs_name, ctx=ast.Del())])
+        )
 
-            new_body.append(ast.Break())
+        new_body.append(ast.Break())
 
-            # Do not stage the while loop if the flag is set to False
-            # TODO: error handling if condition is Argon type
-            if self.loops:
-                # Replace the original while body with the new wrapped body
-                node.body = new_body
+        # Do not stage the while loop if the flag is set to False
+        # TODO: error handling if condition is Argon type
+        if self.loops:
+            # Replace the original while body with the new wrapped body
+            node.body = new_body
 
-                # Set the condition to True and add a break statement at the end of the body
-                # This lets us run the body just once
-                node.test = ast.Constant(value=True)
+            # Set the condition to True and add a break statement at the end of the body
+            # This lets us run the body just once
+            node.test = ast.Constant(value=True)
 
-            self.counter -= 1
-            self.concrete_to_abstract_flag = prev_concrete_to_abstract_flag
+        self.counter -= 1
+        self.concrete_to_abstract_flag = prev_concrete_to_abstract_flag
 
         return node

--- a/src/argon/virtualization/virtualizer/virtualizer_top.py
+++ b/src/argon/virtualization/virtualizer/virtualizer_top.py
@@ -1,0 +1,8 @@
+from argon.virtualization.virtualizer.virtualizer_function_call import TransformerFunctionCall
+from argon.virtualization.virtualizer.virtualizer_ifthenelse import TransformerIfThenElse
+from argon.virtualization.virtualizer.virtualizer_loop import TransformerLoop
+
+
+class TransformerTop(TransformerFunctionCall, TransformerIfThenElse, TransformerLoop):
+    def __init__(self, file_name, calls, ifs, if_exps, loops):
+        super().__init__(file_name, calls, ifs, if_exps, loops)

--- a/src/argon/virtualization/wrapper.py
+++ b/src/argon/virtualization/wrapper.py
@@ -5,7 +5,9 @@ import typing
 
 from argon.types.function import FunctionWithVirt
 from argon.virtualization.func import ArgonFunction
-from argon.virtualization.virtualizer import Transformer
+from argon.virtualization.virtualizer.virtualizer_top import (
+    TransformerTop as Transformer,
+)
 
 
 # TODO: After implementing more transformations, add relevant flags to the decorator to enable/disable them

--- a/src/argon/virtualization/wrapper.py
+++ b/src/argon/virtualization/wrapper.py
@@ -9,7 +9,7 @@ from argon.virtualization.virtualizer import Transformer
 
 
 # TODO: After implementing more transformations, add relevant flags to the decorator to enable/disable them
-def argon_function(calls=True, ifs=True, if_exps=True):
+def argon_function(calls=True, ifs=True, if_exps=True, loops=True):
     """
     This decorator is used to virtualize a function. It takes three optional arguments that are by default all set to True:
 
@@ -19,6 +19,8 @@ def argon_function(calls=True, ifs=True, if_exps=True):
             Determines whether if statements will be virtualized.
         if_exps: bool
             Determines whether if expressions will be virtualized.
+        loops: bool
+            Determines whether loops will be virtualized.
 
     Examples:
 
@@ -63,7 +65,7 @@ def argon_function(calls=True, ifs=True, if_exps=True):
 
         # Apply the AST transformation
         # TODO: Add the transformation flags here too!
-        transformed = Transformer(src, calls, ifs, if_exps).visit(func_src)
+        transformed = Transformer(src, calls, ifs, if_exps, loops).visit(func_src)
         transformed = ast.fix_missing_locations(transformed)
 
         # Create a new AST containing only the transformed function

--- a/src/argon/virtualization/wrapper.py
+++ b/src/argon/virtualization/wrapper.py
@@ -45,6 +45,7 @@ def argon_function(calls=True, ifs=True, if_exps=True, loops=True):
 
         # Remove the decorators from the AST, because the modified function will
         # be passed to them anyway and we don't want them to be called twice.
+        func_src = None
         for node in parsed.body:
             if isinstance(node, ast.FunctionDef) and node.name == func.__name__:
                 node.decorator_list = [
@@ -64,6 +65,9 @@ def argon_function(calls=True, ifs=True, if_exps=True, loops=True):
                 )
                 func_src = node
                 break
+
+        if func_src is None:
+            raise ValueError(f"Unable to virtualize {func.__name__} in file {src}")
 
         # Apply the AST transformation
         # TODO: Add the transformation flags here too!

--- a/tests/test_c_to_a.py
+++ b/tests/test_c_to_a.py
@@ -30,5 +30,5 @@ def test_c_to_a():
 
         d = func
         d1 = concrete_to_abstract.function(d, [concrete_to_abstract(3)])
-        assert d1.F is Integer
+        assert d1.RETURN_TP is Integer
     print(state)

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -1,5 +1,4 @@
 from argon.state import State
-from argon.types.integer import Integer
 from argon.virtualization.wrapper import argon_function
 from collections import namedtuple
 
@@ -30,7 +29,7 @@ def my_func(x, y):
     return x + y
 
 
-@argon_function(calls=True, if_exps=False)
+@argon_function(if_exps=False)
 def ifs():
     a = True
     b = False
@@ -66,19 +65,16 @@ def test_ifs():
     print(state)
 
 
-@argon_function(loops=True)
+@argon_function()
 def loops():
-    a = 0
-    b = 1
-    c = 2 if True else 3
-    while a < 10:
-        a = 1
-        a = a + 1
-        a = a + 2
-        b = b + 2
-        d = c + 1
-        e = 1
-        f = e + 1
+    a = 1
+    b = 2
+    c = 3
+    while a < 100:
+        a = b + 10
+        b = a + 20
+        d = c + 30
+        e = d + 40
 
 
 def test_loops():

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -75,6 +75,7 @@ def loops():
         b = a + 20
         d = c + 30
         e = d + 40
+        f = e < 200
 
 
 def test_loops():

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -6,12 +6,13 @@ from argon.virtualization.wrapper import argon_function
 def if_exps():
     a = True
     b = False
-    c = 3
-    d = 6
-    e = 9
-    f = 12
-    g = c + d if a & b else e + f
-    h = g + g if a | b else 15
+    c = True
+    d = 3
+    e = 6
+    f = 9
+    g = 12
+    h = d + e if a & b & c else f + g
+    i = h + h if a | b | c else 15
 
 
 def test_if_exps():
@@ -31,30 +32,27 @@ def my_func(x, y):
 def ifs():
     a = True
     b = False
-    c = 3
-    d = 6
-    e = 9
-    f = 12
-    g = 15
-    h = 18
-    i = 21
-    j = 24
-    k = 27
-    l = 30
+    c = True
+    d = 3
+    e = 6
+    f = 9
+    g = 12
+    h = 15
+    i = 18
+    j = 21
+    k = 24
 
-    if a & b:
-        m = my_func(c, d)
-        l = 35 if a | b else 33
-    else:
-        m = e + f
+    if a & b & c:
+        l = my_func(d, e)
+        k = 35 if a | b | c else 33
 
-    if a | b:
-        m = g + h
+    if a | b | c:
+        l = f + g
     else:
-        if a ^ b:
-            m = i + j
+        if a ^ b ^ c:
+            l = h + i
         else:
-            m = k + l
+            l = j + k
 
 
 def test_ifs():

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -1,5 +1,7 @@
 from argon.state import State
+from argon.types.integer import Integer
 from argon.virtualization.wrapper import argon_function
+from collections import namedtuple
 
 
 @argon_function(calls=False, ifs=False)
@@ -61,4 +63,28 @@ def test_ifs():
         ifs.virtualized.call_transformed()
 
     print(f"\ntest_ifs")
+    print(state)
+
+
+@argon_function(loops=True)
+def loops():
+    a = 0
+    b = 1
+    c = 2 if True else 3
+    while a < 10:
+        a = 1
+        a = a + 1
+        a = a + 2
+        b = b + 2
+        d = c + 1
+        e = 1
+        f = e + 1
+
+
+def test_loops():
+    state = State()
+    with state:
+        loops.virtualized.call_transformed()
+
+    print(f"\ntest_loops")
     print(state)

--- a/tests/test_integer.py
+++ b/tests/test_integer.py
@@ -1,0 +1,18 @@
+from argon.state import State
+from argon.types.integer import Integer
+
+
+def test_integer():
+    state = State()
+    with state:
+        a = Integer().const(3)
+        b = 6
+        c = a + b
+        d = b + a
+        e = a - b
+        f = b - a
+        g = a > b
+        h = b > a
+        i = a < b
+        j = b < a
+    print(state)


### PR DESCRIPTION
# Supporting the Staging of While Loops

## Creating a new Loop Op

### Bound Variables
The first two class attributes of the `Loop` `Op` are `values` and `binds` respectively. Within Python while loops, we could have various variables that are read from (some of which could be getting their value from prior to the loop, and some of which could be getting their value from previous iterations of the loop) and various variables that are written to (which both impacts future reads across loop iterations, as well as future reads after the loop finishes executing). Most importantly, when considering the overall effects of a loop and being able to stage a node that accurately reflects that loop, we are especially concerned with accesses to variables that are modified across loop iterations.

We address this by creating binds for each variable that is modified across loop iterations. We propose the following definition for when a variable should be bound in this context: if a variable was previously read in the loop and then subsequently written to in the same iteration. Let us illustrate this with three examples:

1. In this first piece of code below, the variable `a` is being read, but never written to. This case is straightforward - since the variable `a` is never written to, it is not modified across loop iterations. Based on our criterion for bound variables, `a` is thus NOT a bind.

    ```python
    def loops():
        a = 0
        while cond:
            output = a
    ```

2. In this second piece of code below, the variable `a` is first written to, then subsequently read from in the same iteration. Since the variable `a` is now in some sense killed first before being read from, it doesn't directly carry any information about its value from the previous iterations whenever we read it. Now, it is true that the variable `a` could still be changing across loop iterations, but that is only possible if it has a bind as its input, so it is unnecessary to make `a` a bound variable to further illustrate that. Thus, based on our criterion for bound variables, `a` is also NOT a bind in this case.

    ```python
    def loops():
        a = 0
        while cond:
            a = 1
            output = a
    ```

3. In this third piece of code below, the variable `a` is first read from (on the RHS of the first assign statement in the loop body), then subsequently written to (in the LHS of that same assign statement). In this case, the first read of `a` on every loop iteration gets the final value of `a` from the previous iteration (or if we are on the first iteration, the final value of `a` from prior to the loop). Subsequent writes to `a` in the same iteration then indicate that `a` could be changing across iterations. Thus, based on our criterion for bound variables, `a` is and should be a bind in this case.

    ```python
    def loops():
        a = 0
        while cond:
            a = a + 1
            output = a
    ```

Based on the criterion mentioned above, we capture a loop's bound variables in a list called `binds` as a class attribute of `Loop`. Next, notice that as a result of how we defined bound variables for loops, on the first iteration, we will always read the final value of that variable from prior to the loop. We thus also need to capture those as the initial values for the binds we created, and they are stored in a list called `values` as a class attribute of `Loop`. Each bind-value pair will occupy the same indices in `binds` and `loops`.

### Loop Condition and Body
The next two class attributes of the `Loop` `Op` are `cond` and `body`, which respectively store the graph we get from executing our the loop condition and loop body with our binds. Intuitively, `cond` should be a `Block[Boolean]` and `body` should be a `Block[Null]`.

### Loop Outputs
The final class attribute of the `Loop` `Op` is `outputs`. This field stores each variable's value after every iteration for all the variables that are written to within the loop. For now, we made `outputs` a NamedTuple for a clear mapping between each variable's name and its final staged value after a particular iteration.

### Class Definition
Putting everything together, the `Loop` `Op` thus looks like:
```python
@dataclass(config=pydantic.ConfigDict(arbitrary_types_allowed=True))
class Loop[T](Op[T]):
    ...
    values: typing.List[Exp[typing.Any, typing.Any]]
    binds: typing.List[Exp[typing.Any, typing.Any]]
    cond: Block[Boolean]
    body: Block[Null]
    outputs: typing.Any

    @pydantic.field_validator("outputs")
    def check_outputs(cls, v):
        if not hasattr(v, "_fields") or not hasattr(v, "_asdict"):
            raise ValueError("outputs must be a namedtuple or similar structure.")
        return v
    ...
```

* Side note: as usual, the type parameter `T` represents the type we would get from staging a `Loop` node. More details on what `T` should be in the next section.

## Staging a Loop Node

### Representing the Outputs of a Loop
Recall that in Python, while loops run in the same scope as their enclosing block. As a result, we mentioned previously that all variables that are written to in a loop are outputs of the loop, directly affecting subsequent reads after the loop. The `outputs` field of `Loop` currently stores the staged results of modified variables at the end of each iteration, which could be dependent on the loop's bound variables. However, binds don’t exist outside of the loop, meaning we need some degree of separation between the loop condition/body and outside of the loop.

### Struct
To address this, we propose that the result of staging a `Loop` node should give us some structure that represents that loop's outputs. The structure we propose is an Argon `Struct` type. In order to capture the type of all members of the `Struct`, the type parameter `MEMBERS_TP` of `Struct` will be a dictionary that maps member names to member types.

```python
class Struct[MEMBERS_TP](Ref[dict, "Struct[MEMBERS_TP]"]):
    ...
```

### Get Op
In order to access individual members of a struct, we also introduce a `Get` `Op` that stores a `struct` field for the `Struct` we want to access from and a `key` field, which is a string for the member name we want to access.

```python
@dataclass(config=pydantic.ConfigDict(arbitrary_types_allowed=True))
class Get[T](Op[T]):
    # Note: The proper type should be a Struct whose type parameter contains an element T
    struct: Struct
    key: str
    ...
```
* Side note: the proper type of `struct` shouldn't just be a `Struct`, but instead a `Struct` that has a type parameter `MEMBERS_TP` where `MEMBERS_TP[key]` is the type that the `Get` `Op` should return.

### Combining Struct and Get
I then implement the dunder function `__getitem__` for Struct, which stages `Get` `Op`s for members of the Struct. Taking us back to the context of capturing loop outputs, whenever we encounter a while loop, we should stage a `Loop` node, which gets us a `Struct` `S`. The `Struct` `S` represents all the final values of all the variables that are modified in the loop. Subsequent accesses to a modified variable `a` should then reference an instance of the correct type of `a` where the rhs is a `Get(S, "a")` node.

```python
def __getitem__(self, key: str) -> MEMBERS_TP:  # type: ignore -- Pyright falsely detects MEMBERS_TP as an abstractproperty instead of type variable
        try:
            item_tp = self.MEMBERS_TP[key]
        except KeyError:
            raise KeyError(f"Key '{key}' not found in dictionary {self}")

        from argon.node.struct_ops import Get

        return stage(Get[item_tp](self, key), ctx=SrcCtx.new(2))
```

## Virtualizing While Loops

### Dataflow Analysis for Read and Write Sets
In order to analyze which variables in a loop should be binds, we employ a data flow framework that keeps track of the read and write sets of the loop. Since the condition of a loop is always evaluated first before the body is executed, we treat the loop as if its condition is directly followed by its body. In our analysis framework, we define the read set of a loop to be variables that are read within the loop but haven't been killed/written to prior. We define the write set to be variables that are written to.

The analysis then becomes quite simple. For every statement in the loop, we append the statement's reads to the loop read set if those variables are not already in the loop write set, and we append all the statement's writes to the loop write set. With this formulation now, the binds of a loop is the intersection of the loop read and write sets after we finish analyzing the loop.

Here is an example to illustrate the concept above. Let `sr` and `sw` be a statements read and write sets, and let `lr` and `lw` be the loop's read and write sets at the end of a given statement. At the end of the loop, the intersection of the loop's read and write sets is {a, b}, which mean that our bound variables are therefore `a` and `b` as expected.

```python
a = 1
b = 1
c = 3
while a < 100: # sr: {a}, sw: {}; lr: {a}, lw: {}
    a = b + 10 # sr: {b}, sw: {a}; lr: {a, b}, lw: {a}
    b = a + 20 # sr: {a}, sw: {b}; lr: {a, b}, lw: {a, b}
    d = c + 30 # sr: {c}, sw: {d}; lr: {a, b, c}, lw: {a, b, d}
    e = d + 40 # sr: {d}, sw: {e}; lr: {a, b, c}, lw: {a, b, d, e}
```

In order to implement this, we work off of our existing ast NodeTransformer infrastructure that we use to virtualize other types of control flow. This is also quite convenient, as the NodeTransformer automatically takes care of the ast traversal to access every ast node. To keep track of read and write sets, we implement a `VariableTracker` that stores the read and write sets of a given ast node on a stack, along with the read and write sets of the all the parents of that ast node. We also introduce a `fold_context` function that handles the updating of read and write sets.

```python
class VariableTracker:
    def __init__(self):
        self.write_set_stack = [set()]
        self.read_set_stack = [set()]

    def push_context(self):
        self.write_set_stack.append(set())
        self.read_set_stack.append(set())

    ...

    def fold_context(self):
        curr_read_set = self.read_set_stack.pop()
        curr_write_set = self.write_set_stack.pop()
        self.current_read_set().update(curr_read_set - self.current_write_set())
        self.current_write_set().update(curr_write_set)

    ...
```

Our NodeTransformer will then contain an instance of this VariableTracker. For every node in the ast, we will call `push_context` to allocate its own read/write sets on the VariableTracker stack. We will then recursively visit the ast node. And finally, we call `fold_context` before returning. This is done by implementing NodeTransformer's `visit` function.

```python
def visit(self, node):
    self.variable_tracker.push_context()
    node = super().visit(node)
    self.variable_tracker.fold_context()
    return node
```

Every time we see an assign statement, we can add the lhs to the current write set, and every time we see an ast Name node that is a load, we can add to the current read set.

### AST Transformations
Finally, we need to apply ast transformations to the loop to properly stage everything. At the beginning of the `visit_While` function, we first recursively visit the loop condition and body to properly virtualize them as well as perform the dataflow analysis to get our read and write sets to determine our bound variables.

Since the visit_While function must return an ast While node, in order to still be able to properly virtualize our loop, we need to return a new While node where the condition is `True`, the body is all our code that stages the loop properly, followed by a `break`. This allows us to stage the loop once while still maintaining an ast While node.

For the body of this ast While node that we need to return, we first append nodes to create the proper binds and add the binds and values to temporary binds and values lists. Then, we create a `Scope` to execute the loop condition, and then we create another `Scope` to execute the loop body. Next, we create a namedtuple for the loop outputs. We can then stage a Loop node with the binds, values, condition graph, body graph, and outputs that we've captured to get a `Struct`. Finally, for each modified variable of the loop, we stage a `Get` node on the `Struct`; then we delete all our temporary variables and break.

* Final note: the code above is able to stage while loops and nested while loops correctly as expected. More work needs to be done to correctly stage while loops that contain other types of control flow like if statements.