### PR TITLE
Functions2

### DIFF
--- a/src/argon/ref.py
+++ b/src/argon/ref.py
@@ -19,6 +19,10 @@ class ExpType[C, A](ArgonMeta, abc.ABC):
     type A. This class should be subclassed to define custom expression types.
     """
 
+    @classmethod
+    def type_name(cls) -> str:
+        return cls.__name__
+
     @abc.abstractmethod
     def fresh(self) -> A:
         raise NotImplementedError()
@@ -58,7 +62,7 @@ class ExpType[C, A](ArgonMeta, abc.ABC):
 
     @property
     def tp_name(self) -> str:
-        return self.__class__.__name__
+        return self.type_name()
 
 
 @dataclass

--- a/src/argon/types/boolean.py
+++ b/src/argon/types/boolean.py
@@ -5,7 +5,7 @@ from argon.srcctx import SrcCtx
 from argon.state import stage
 
 import argon.node.logical as logical
-from argon.virtualization.type_mapper import concrete_to_abstract, concrete_to_bound
+from argon.virtualization.type_mapper import concrete_to_abstract, concrete_to_bound, concrete_to_abstract_type
 
 
 class Boolean(Ref[bool, "Boolean"]):
@@ -44,3 +44,4 @@ class Boolean(Ref[bool, "Boolean"]):
 
 concrete_to_abstract[bool] = lambda x: Boolean().const(x)
 concrete_to_bound[bool] = lambda name: Boolean().bound(name)
+concrete_to_abstract_type[bool] = Boolean

--- a/src/argon/types/boolean.py
+++ b/src/argon/types/boolean.py
@@ -5,7 +5,7 @@ from argon.srcctx import SrcCtx
 from argon.state import stage
 
 import argon.node.logical as logical
-from argon.virtualization.type_mapper import concrete_to_abstract
+from argon.virtualization.type_mapper import concrete_to_abstract, concrete_to_bound
 
 
 class Boolean(Ref[bool, "Boolean"]):
@@ -43,3 +43,4 @@ class Boolean(Ref[bool, "Boolean"]):
 
 
 concrete_to_abstract[bool] = lambda x: Boolean().const(x)
+concrete_to_bound[bool] = lambda name: Boolean().bound(name)

--- a/src/argon/types/function.py
+++ b/src/argon/types/function.py
@@ -37,6 +37,18 @@ class Function[RETURN_TP](Ref[FunctionWithVirt, "Function[RETURN_TP]"]):
     def RETURN_TP(self) -> typing.Type[RETURN_TP]:
         raise NotImplementedError()
 
+    @override
+    @property
+    def tp_name(self) -> str:
+        result = f"{self.type_name()}[{self.RETURN_TP.type_name()}"
+        current_type = self.RETURN_TP
+        while get_args(current_type):
+            args = get_args(current_type)
+            result += f"[{args[0].type_name()}"
+            current_type = args[0]
+        result += "]" * (result.count("[") - result.count("]"))
+        return result
+
 
 def function_C_to_A(c: types.FunctionType) -> Function:
     if not (hasattr(c, "virtualized") and isinstance(c.virtualized, ArgonFunction)):  # type: ignore -- Pyright complains about accessing virtualized
@@ -95,7 +107,6 @@ def function_C_to_B(name: str, func_tp: typing.Callable) -> Function:
         return Function[Integer]().bound(name)
     else:
         raise ValueError(f"The return type {func_ret_tp} is not supported")
-
 
 
 concrete_to_bound[types.FunctionType] = function_C_to_B

--- a/src/argon/types/integer.py
+++ b/src/argon/types/integer.py
@@ -5,7 +5,7 @@ from argon.ref import Ref
 from argon.srcctx import SrcCtx
 from argon.state import stage
 from argon.types.boolean import Boolean
-from argon.virtualization.type_mapper import concrete_to_abstract
+from argon.virtualization.type_mapper import concrete_to_abstract, concrete_to_bound
 
 
 class Integer(Ref[int, "Integer"]):
@@ -49,3 +49,4 @@ class Integer(Ref[int, "Integer"]):
 
 
 concrete_to_abstract[int] = lambda x: Integer().const(x)
+concrete_to_bound[int] = lambda name: Integer().bound(name)

--- a/src/argon/types/integer.py
+++ b/src/argon/types/integer.py
@@ -5,7 +5,7 @@ from argon.ref import Ref
 from argon.srcctx import SrcCtx
 from argon.state import stage
 from argon.types.boolean import Boolean
-from argon.virtualization.type_mapper import concrete_to_abstract, concrete_to_bound
+from argon.virtualization.type_mapper import concrete_to_abstract, concrete_to_bound, concrete_to_abstract_type
 
 
 class Integer(Ref[int, "Integer"]):
@@ -50,3 +50,4 @@ class Integer(Ref[int, "Integer"]):
 
 concrete_to_abstract[int] = lambda x: Integer().const(x)
 concrete_to_bound[int] = lambda name: Integer().bound(name)
+concrete_to_abstract_type[int] = Integer

--- a/src/argon/types/null.py
+++ b/src/argon/types/null.py
@@ -1,7 +1,7 @@
 from types import NoneType
 from typing import override
 from argon.ref import Ref
-from argon.virtualization.type_mapper import concrete_to_abstract, concrete_to_bound
+from argon.virtualization.type_mapper import concrete_to_abstract, concrete_to_bound, concrete_to_abstract_type
 
 
 class Null(Ref[NoneType, "Null"]):
@@ -16,3 +16,4 @@ class Null(Ref[NoneType, "Null"]):
 
 concrete_to_abstract[NoneType] = lambda x: Null().const(x)
 concrete_to_bound[NoneType] = lambda name: (_ for _ in ()).throw(TypeError("Cannot bind NoneType"))
+concrete_to_abstract_type[NoneType] = Null

--- a/src/argon/types/null.py
+++ b/src/argon/types/null.py
@@ -1,7 +1,7 @@
 from types import NoneType
 from typing import override
 from argon.ref import Ref
-from argon.virtualization.type_mapper import concrete_to_abstract
+from argon.virtualization.type_mapper import concrete_to_abstract, concrete_to_bound
 
 
 class Null(Ref[NoneType, "Null"]):
@@ -15,3 +15,4 @@ class Null(Ref[NoneType, "Null"]):
 
 
 concrete_to_abstract[NoneType] = lambda x: Null().const(x)
+concrete_to_bound[NoneType] = lambda name: (_ for _ in ()).throw(TypeError("Cannot bind NoneType"))

--- a/src/argon/virtualization/func.py
+++ b/src/argon/virtualization/func.py
@@ -1,4 +1,3 @@
-import inspect
 import typing
 import pydantic
 from pydantic.dataclasses import dataclass
@@ -12,6 +11,7 @@ class ArgonFunction:
     transformed_func: typing.Callable
     return_type: typing.Type | typing.Callable
     param_types: typing.Dict[str, typing.Type | typing.Callable]
+    abstract_func: typing.Optional["Function"]
 
     @property
     def argon(self):

--- a/src/argon/virtualization/func.py
+++ b/src/argon/virtualization/func.py
@@ -1,16 +1,17 @@
 import inspect
 import typing
+import pydantic
 from pydantic.dataclasses import dataclass
 
 import argon
 
 
-@dataclass
+@dataclass(config=pydantic.ConfigDict(arbitrary_types_allowed=True))
 class ArgonFunction:
     original_func: typing.Callable
     transformed_func: typing.Callable
-    return_type: typing.Type
-    param_types: typing.Dict[str, typing.Type]
+    return_type: typing.Type | typing.Callable
+    param_types: typing.Dict[str, typing.Type | typing.Callable]
 
     @property
     def argon(self):
@@ -25,5 +26,10 @@ class ArgonFunction:
     get_function_name = lambda self: self.original_func.__name__
 
     def get_param_names(self) -> list[str]:
-        sig = inspect.signature(self.original_func)
-        return [param.name for param in sig.parameters.values()]
+        return list(self.param_types.keys())
+
+    def get_param_type(self, param_name: str) -> typing.Type | typing.Callable:
+        return self.param_types[param_name]
+
+    def get_return_type(self) -> typing.Type | typing.Callable:
+        return self.return_type

--- a/src/argon/virtualization/func.py
+++ b/src/argon/virtualization/func.py
@@ -9,6 +9,8 @@ import argon
 class ArgonFunction:
     original_func: typing.Callable
     transformed_func: typing.Callable
+    return_type: typing.Type
+    param_types: typing.Dict[str, typing.Type]
 
     @property
     def argon(self):

--- a/src/argon/virtualization/type_mapper.py
+++ b/src/argon/virtualization/type_mapper.py
@@ -1,4 +1,3 @@
-import types
 import typing
 from argon.ref import Ref
 
@@ -12,15 +11,6 @@ class _CToA:
     def __setitem__(self, tp_c, tp_a_initializer: typing.Callable) -> None:
         self.C_to_A_map[tp_c] = tp_a_initializer
 
-    def function(self, c, args: typing.List[Ref[typing.Any, typing.Any]]) -> "Function":
-        # Unwrap the function if it's decorated
-        while hasattr(c, "__wrapped__"):
-            c = c.__wrapped__
-
-        if not isinstance(c, types.FunctionType):
-            raise ValueError(f"Expected function, got {c}")
-        return self.C_to_A_map[types.FunctionType](c, args)
-
     def __call__(self, c) -> Ref[typing.Any, typing.Any]:
         if type(c) in self.C_to_A_map:
             return self.C_to_A_map[type(c)](c)
@@ -32,8 +22,6 @@ class _CToA:
 
 concrete_to_abstract = _CToA()
 
-from argon.types.function import Function
-
 # This class is used to map a concrete type to a bound variable
 # of its corresponding abstract type
 class _CToB:
@@ -43,9 +31,10 @@ class _CToB:
     def __setitem__(self, tp_c, tp_b_initializer: typing.Callable) -> None:
         self.C_to_B_map[tp_c] = tp_b_initializer
     
-    def __call__(self, tp_c, name: str) -> Ref[typing.Any, typing.Any]:
+    # TODO: make the return type more specific
+    def __getitem__(self, tp_c) -> typing.Callable:
         if tp_c in self.C_to_B_map:
-            return self.C_to_B_map[tp_c](name)
+            return self.C_to_B_map[tp_c]
         else:
             raise ValueError(f"Cannot convert {tp_c} to bound variable")
 

--- a/src/argon/virtualization/type_mapper.py
+++ b/src/argon/virtualization/type_mapper.py
@@ -3,6 +3,8 @@ import typing
 from argon.ref import Ref
 
 
+# This class is used to map an instance of a concrete type 
+# to an instance of its corresponding abstract type
 class _CToA:
     def __init__(self):
         self.C_to_A_map = {}
@@ -31,3 +33,20 @@ class _CToA:
 concrete_to_abstract = _CToA()
 
 from argon.types.function import Function
+
+# This class is used to map a concrete type to a bound variable
+# of its corresponding abstract type
+class _CToB:
+    def __init__(self):
+        self.C_to_B_map = {}
+    
+    def __setitem__(self, tp_c, tp_b_initializer: typing.Callable) -> None:
+        self.C_to_B_map[tp_c] = tp_b_initializer
+    
+    def __call__(self, tp_c, name: str) -> Ref[typing.Any, typing.Any]:
+        if tp_c in self.C_to_B_map:
+            return self.C_to_B_map[tp_c](name)
+        else:
+            raise ValueError(f"Cannot convert {tp_c} to bound variable")
+
+concrete_to_bound = _CToB()

--- a/src/argon/virtualization/type_mapper.py
+++ b/src/argon/virtualization/type_mapper.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+import types
 import typing
 from argon.ref import Ref
 
@@ -33,9 +35,34 @@ class _CToB:
     
     # TODO: make the return type more specific
     def __getitem__(self, tp_c) -> typing.Callable:
-        if tp_c in self.C_to_B_map:
+        if typing.get_origin(tp_c) is Callable:
+            return self.C_to_B_map[types.FunctionType](tp_c)
+        elif tp_c == types.FunctionType:
+            raise ValueError(f"Cannot convert {tp_c} to bound variable, use typing.Callable and specify the parameter and return types")
+        elif tp_c in self.C_to_B_map:
             return self.C_to_B_map[tp_c]
         else:
             raise ValueError(f"Cannot convert {tp_c} to bound variable")
 
 concrete_to_bound = _CToB()
+
+# This class is used to map a concrete type to its corresponding
+# abstract type
+class _CToAT:
+    def __init__(self):
+        self.C_to_AT_map = {}
+    
+    def __setitem__(self, tp_c, tp_a) -> None:
+        self.C_to_AT_map[tp_c] = tp_a
+    
+    def __getitem__(self, tp_c) -> typing.Type[Ref[typing.Any, typing.Any]]:
+        if typing.get_origin(tp_c) is Callable:
+            return self.C_to_AT_map[types.FunctionType](tp_c)
+        elif tp_c == types.FunctionType:
+            raise ValueError(f"Cannot convert {tp_c} to abstract type, use typing.Callable and specify the parameter and return types")
+        elif tp_c in self.C_to_AT_map:
+            return self.C_to_AT_map[tp_c]
+        else:
+            raise ValueError(f"Cannot convert {tp_c} to abstract type")
+
+concrete_to_abstract_type = _CToAT()

--- a/src/argon/virtualization/virtualizer/virtualizer_function_call.py
+++ b/src/argon/virtualization/virtualizer/virtualizer_function_call.py
@@ -20,9 +20,11 @@ def stage_function_call(
         return func(*args)
 
     abstract_args = [concrete_to_abstract(arg) for arg in args]
-    abstract_func = concrete_to_abstract.function(func, abstract_args)
+    abstract_func = concrete_to_abstract(func)
+    # TODO: check if arg types match the function signature
     return stage(
-        FunctionCall[abstract_func.RETURN_TP](abstract_func, abstract_args), ctx=SrcCtx.new(2)
+        FunctionCall[abstract_func.RETURN_TP](abstract_func, abstract_args),
+        ctx=SrcCtx.new(2),
     )
 
 

--- a/src/argon/virtualization/virtualizer/virtualizer_function_call.py
+++ b/src/argon/virtualization/virtualizer/virtualizer_function_call.py
@@ -19,8 +19,8 @@ def stage_function_call(
     if func in white_list:
         return func(*args)
 
-    abstract_args = [concrete_to_abstract(arg) for arg in args]
     abstract_func = concrete_to_abstract(func)
+    abstract_args = [concrete_to_abstract(arg) for arg in args]
     # TODO: check if arg types match the function signature
     return stage(
         FunctionCall[abstract_func.RETURN_TP](abstract_func, abstract_args),

--- a/src/argon/virtualization/wrapper.py
+++ b/src/argon/virtualization/wrapper.py
@@ -38,7 +38,9 @@ def argon_function(calls=True, ifs=True, if_exps=True, loops=True):
         # Get type hints of the function
         type_hints = typing.get_type_hints(func)
         if "return" not in type_hints:
-            raise TypeError(f"Function {func.__name__} must have a return type annotation")
+            raise TypeError(
+                f"Function {func.__name__} must have a return type annotation"
+            )
         for param_name, param in inspect.signature(func).parameters.items():
             if param.annotation == inspect.Parameter.empty:
                 raise TypeError(
@@ -99,7 +101,11 @@ def argon_function(calls=True, ifs=True, if_exps=True, loops=True):
 
         # Replace the original function with the transformed version
         virtualized_func = ArgonFunction(
-            func, functools.update_wrapper(func_globals[func.__name__], func), return_type, param_types
+            func,
+            functools.update_wrapper(func_globals[func.__name__], func),
+            return_type,
+            param_types,
+            abstract_func=None,
         )
 
         # Create a wrapper function that calls the transformed function

--- a/tests/test_c_to_a.py
+++ b/tests/test_c_to_a.py
@@ -6,7 +6,7 @@ from argon.types.null import Null
 from argon.virtualization.type_mapper import concrete_to_abstract
 
 
-def func(x):
+def func(x: int) -> int:
     return x
 
 
@@ -29,6 +29,6 @@ def test_c_to_a():
         assert c1.A is Null
 
         d = func
-        d1 = concrete_to_abstract.function(d, [concrete_to_abstract(3)])
+        d1 = concrete_to_abstract(d)
         assert d1.RETURN_TP is Integer
     print(state)

--- a/tests/test_c_to_at.py
+++ b/tests/test_c_to_at.py
@@ -1,0 +1,38 @@
+from types import NoneType
+import types
+import typing
+from argon.state import State
+from argon.types.boolean import Boolean
+from argon.types.function import Function
+from argon.types.integer import Integer
+from argon.types.null import Null
+from argon.virtualization.type_mapper import concrete_to_abstract_type
+
+
+def func(x):
+    return x
+
+
+def test_c_to_at():
+    state = State()
+    with state:
+        a = concrete_to_abstract_type[int]
+        assert a is Integer
+
+        b = concrete_to_abstract_type[bool]
+        assert b is Boolean
+
+        c = concrete_to_abstract_type[NoneType]
+        assert c is Null
+
+        d = concrete_to_abstract_type[typing.Callable[..., int]]
+        assert d is Function[Integer]
+
+        try:
+            e = concrete_to_abstract_type[types.FunctionType]
+        except ValueError as e:
+            assert str(e) == f"Cannot convert {types.FunctionType} to abstract type, use typing.Callable and specify the parameter and return types"
+        
+        f = concrete_to_abstract_type[typing.Callable[..., typing.Callable[..., bool]]]
+        assert f is Function[Function[Boolean]]
+    print(state)

--- a/tests/test_c_to_b.py
+++ b/tests/test_c_to_b.py
@@ -1,6 +1,9 @@
 from types import NoneType
+import types
+import typing
 from argon.state import State
 from argon.types.boolean import Boolean
+from argon.types.function import Function, FunctionWithVirt
 from argon.types.integer import Integer
 from argon.virtualization.type_mapper import concrete_to_bound
 
@@ -9,23 +12,29 @@ def func(x):
     return x
 
 
-def test_c_to_a():
+def test_c_to_b():
     state = State()
     with state:
-        a = concrete_to_bound(int, "a")
+        a = concrete_to_bound[int]("a")
         assert a.C is int
         assert a.A is Integer
         assert a.is_bound()
         assert a.rhs.val.name == "a"
 
-        b = concrete_to_bound(bool, "b")
+        b = concrete_to_bound[bool]("b")
         assert b.C is bool
         assert b.A is Boolean
         assert b.is_bound()
         assert b.rhs.val.name == "b"
 
         try:
-            c = concrete_to_bound(NoneType, "c")
+            c = concrete_to_bound[NoneType]("c")
         except TypeError as e:
             assert str(e) == "Cannot bind NoneType"
+        
+        d = concrete_to_bound[types.FunctionType]("d", typing.Callable[[int, int], int])
+        assert d.C is FunctionWithVirt
+        assert d.A is Function[Integer]
+        assert d.is_bound()
+        assert d.rhs.val.name == "d"
     print(state)

--- a/tests/test_c_to_b.py
+++ b/tests/test_c_to_b.py
@@ -1,0 +1,31 @@
+from types import NoneType
+from argon.state import State
+from argon.types.boolean import Boolean
+from argon.types.integer import Integer
+from argon.virtualization.type_mapper import concrete_to_bound
+
+
+def func(x):
+    return x
+
+
+def test_c_to_a():
+    state = State()
+    with state:
+        a = concrete_to_bound(int, "a")
+        assert a.C is int
+        assert a.A is Integer
+        assert a.is_bound()
+        assert a.rhs.val.name == "a"
+
+        b = concrete_to_bound(bool, "b")
+        assert b.C is bool
+        assert b.A is Boolean
+        assert b.is_bound()
+        assert b.rhs.val.name == "b"
+
+        try:
+            c = concrete_to_bound(NoneType, "c")
+        except TypeError as e:
+            assert str(e) == "Cannot bind NoneType"
+    print(state)

--- a/tests/test_c_to_b.py
+++ b/tests/test_c_to_b.py
@@ -1,5 +1,4 @@
 from types import NoneType
-import types
 import typing
 from argon.state import State
 from argon.types.boolean import Boolean
@@ -32,7 +31,7 @@ def test_c_to_b():
         except TypeError as e:
             assert str(e) == "Cannot bind NoneType"
         
-        d = concrete_to_bound[types.FunctionType]("d", typing.Callable[[int, int], int])
+        d = concrete_to_bound[typing.Callable[[int, int], int]]("d")
         assert d.C is FunctionWithVirt
         assert d.A is Function[Integer]
         assert d.is_bound()

--- a/tests/test_control.py
+++ b/tests/test_control.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 
 
 @argon_function(calls=False, ifs=False)
-def if_exps():
+def if_exps() -> None:
     a = True
     b = False
     c = True
@@ -25,12 +25,12 @@ def test_if_exps():
     print(state)
 
 
-def my_func(x, y):
+def my_func(x: int, y: int) -> int:
     return x + y
 
 
 @argon_function(if_exps=False)
-def ifs():
+def ifs() -> None:
     a = True
     b = False
     c = True
@@ -66,7 +66,7 @@ def test_ifs():
 
 
 @argon_function()
-def loops():
+def loops() -> None:
     a = 1
     b = 2
     c = 3

--- a/tests/test_function_call.py
+++ b/tests/test_function_call.py
@@ -3,12 +3,16 @@ from argon.state import State
 from argon.virtualization.wrapper import argon_function
 
 
-def func2(x: int, y: int) -> int:
+def func3(x: int, y: int) -> int:
     return x + y
 
 
-def func1(func: typing.Callable[[int, int], int], x: int, y: int, z: int) -> int:
-    return func(x, y) + z
+def func2() -> typing.Callable[[int, int], int]:
+    return func3
+
+
+def func1(func: typing.Callable[[], typing.Callable[[int, int], int]], x: int, y: int, z: int) -> int:
+    return func()(x, y) + z
 
 
 @argon_function()

--- a/tests/test_function_call.py
+++ b/tests/test_function_call.py
@@ -11,7 +11,9 @@ def func2() -> typing.Callable[[int, int], int]:
     return func3
 
 
-def func1(func: typing.Callable[[], typing.Callable[[int, int], int]], x: int, y: int, z: int) -> int:
+def func1(
+    func: typing.Callable[[], typing.Callable[[int, int], int]], x: int, y: int, z: int
+) -> int:
     return func()(x, y) + z
 
 
@@ -24,4 +26,24 @@ def test_function_call():
     state = State()
     with state:
         function_call.virtualized.call_transformed()
+    print(state)
+
+
+def recursion_call(x: int) -> int:
+    if x < 0:
+        output = 0
+    else:
+        output = recursion_call(x - 1) + 1
+    return output
+
+
+@argon_function()
+def recursion() -> int:
+    return recursion_call(5)
+
+
+def test_recursion():
+    state = State()
+    with state:
+        recursion.virtualized.call_transformed()
     print(state)

--- a/tests/test_function_call.py
+++ b/tests/test_function_call.py
@@ -1,14 +1,19 @@
+import typing
 from argon.state import State
 from argon.virtualization.wrapper import argon_function
 
 
-def func(x, y):
+def func2(x: int, y: int) -> int:
     return x + y
 
 
+def func1(func: typing.Callable[[int, int], int], x: int, y: int, z: int) -> int:
+    return func(x, y) + z
+
+
 @argon_function()
-def function_call():
-    return func(3, 4) + 5
+def function_call() -> int:
+    return func1(func2, 3, 4, 5)
 
 
 def test_function_call():


### PR DESCRIPTION
# Supporting the Staging of Higher-Order Functions and Recursive Functions

## Higher-Order Functions
Supporting higher-order functions (i.e. functions that take other functions as arguments and/or return functions) requires a fundamental shift in how we construct `Function` objects.

Previously, a `Function` was only ever created as part of staging a *function call*. In that setting, we could infer the parameter types of the function from the concrete arguments passed at the call site. This worked because the function was always called immediately, and the call itself provided enough information to deduce both the argument types and the return type.

With higher-order functions, this assumption no longer holds. We now need to be able to:
- Pass functions as values (without calling them),
- Return functions from other functions,
- Construct `Function` objects *before* any call occurs.

As a result, we must know a function’s parameter and return types **ahead of time**, independently of how (or whether) it is eventually called.

### Enforcing Type Annotations

To address this, we require that all virtualized functions have **explicit type annotations** for:
- Every parameter, and
- The return type.

This enforcement happens eagerly in `argon/virtualization/wrapper.py`, during the application of the `argon_function` decorator. Concretely, we extract and validate the function’s type hints as follows:
```python
# Get type hints of the function
type_hints = typing.get_type_hints(func)
if "return" not in type_hints:
    raise TypeError(f"Function {func.__name__} must have a return type annotation")
for param_name, param in inspect.signature(func).parameters.items():
    if param.annotation == inspect.Parameter.empty:
        raise TypeError(
            f"Parameter {param_name} of function {func.__name__} must have a type annotation"
        )
return_type = type_hints.pop("return")
param_types = type_hints
```

The extracted `param_types` and r`eturn_type` are stored as additional metadata on the virtualized function (in `ArgonFunction`). This metadata allows us to construct a `Function` object with a fully known signature *before* the function is ever called, which is essential for higher-order behavior.

### Mapping Concrete Types to Abstract Types and Bound Variables
Python type annotations are necessarily *concrete Python types* (e.g. `int`, `bool`, user-defined classes). However, Argon operates on `abstract types`, so we need a systematic way to translate between the two. Using `concrete_to_abstract` as inspiration, we introduce two new mappings:
- `concrete_to_bound`: this maps a concrete type to a bound variable with the corresponding abstract type, and is used when creating function parameters
- `concrete_to_abstract_type`: this maps a concrete type to its corresponding abstract type, and is used to label `Function`'s type parameter, i.e. its return type

As before, this responsibility is delegated to the user when defining a new Argon type. For each concrete type they introduce, users are now expected to register the following mappings:
- `concrete_to_abstract`
- `concrete_to_bound`
- `concrete_to_abstract_type`

For example, for the `Integer` type:
```python
class Integer(Ref[int, "Integer"]):
    ...

concrete_to_abstract[int] = lambda x: Integer().const(x)
concrete_to_bound[int] = lambda name: Integer().bound(name)
concrete_to_abstract_type[int] = Integer
```

With these mappings in place, we can:
- Convert annotated parameter types into correctly-typed Argon binds,
- Assign the correct abstract return type to Function[F],
- Treat functions as fully-typed first-class values, enabling them to be passed around and returned just like any other Argon object.

This enforcement and mapping infrastructure is what makes staging higher-order functions both sound and compositional within Argon.


## Recursive Functions

### The Problem with Naive Staging
Previously, staging a `Function` worked as follows:
1. Convert the function’s parameters into bound arguments.
2. Execute the virtualized version of the function with those binds.
3. Collect all staged operations into a Block, which becomes the function body.
4. Store this body inside a FunctionNew operation and stage it to produce a Function.

This approach works well for non-recursive functions. However, for recursive functions, it leads to immediate non-termination.

When staging a recursive function, executing the virtualized function body will eventually encounter a call to the same function. That recursive call is itself virtualized, which means we attempt to stage it as a function call. In order to do so, we again try to create a `Function` for the same Python function, which triggers:
- another `FunctionNew`,
- another execution of the function body,
- another recursive call,
- and so on.

Because function staging eagerly executes the function body, this process results in an **infinite recursion during staging**, long before we ever reach runtime execution.

### Separating Function Identity from Function Body
To break this cycle, we need to distinguish between:
- Staging a `FunctionNew` to create an abstract `Function` value
- Staging the body of that function

To support this, we extend the metadata stored in `ArgonFunction` with an additional field:
- `abstract_func: Function`

This field stores the unique abstract `Function` corresponding to the Python function. Importantly, the mapping from a Python function to an `ArgonFunction` is *bijective*, so there is exactly one place where this abstract function can and should live.

### Lazy Body Construction for Recursive Functions
With this change, staging a FunctionNew now proceeds in two phases:
1. Check for an existing abstract function
When we attempt to stage a `FunctionNew`, we first check whether the associated `ArgonFunction` already has an `abstract_func`.
- If it does, we reuse that `Function` immediately.
- If it does not, we create a new `Function` and store it in `abstract_func` *without* fully populating its body yet.
2. Stage the function body exactly once
After establishing the abstract function identity, we execute the virtualized function with bound arguments and collect the resulting `Block`. This block is then attached to the previously created `Function`.

Because recursive calls now encounter an already-existing `abstract_func`, they no longer attempt to create or stage a new `FunctionNew`. Instead, recursive calls simply reference the same abstract function, allowing the function body to contain calls to itself without triggering re-entrance into function staging.